### PR TITLE
Create ~/.bdash/setting.yml with mode=0600

### DIFF
--- a/app/lib/Setting.js
+++ b/app/lib/Setting.js
@@ -17,7 +17,7 @@ export default class Setting {
     this.filePath = filePath;
 
     if (!fs.existsSync(filePath)) {
-      fs.writeFileSync(filePath, '');
+      fs.writeFileSync(filePath, '', { mode: 0o600 });
     }
 
     this.setting = yaml.safeLoad(fs.readFileSync(filePath).toString()) || {};


### PR DESCRIPTION
setting.yml should not be world-readable because it could contain GitHub
personal access token. It might be better if we use another file to
store credentials.