### PR TITLE
[WIP] Add feature to share on bdash server

### DIFF
--- a/app/lib/BdashServerClient.js
+++ b/app/lib/BdashServerClient.js
@@ -1,0 +1,31 @@
+const API_VERSION = 1;
+
+export default class BdashServerClient {
+  constructor({ endpoint, token }) {
+    this.endpoint = endpoint;
+    this.token = token;
+  }
+
+  get headers() {
+    return {
+      'Content-Type': 'application/json',
+      'X-Bdash-API-Token': `token ${this.token}`,
+      'X-Bdash-API-Version': API_VERSION,
+    };
+  }
+
+  async post({ title, body, result, charts }) {
+    let response = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ title, body, result, charts }),
+    });
+
+    if (response.ok) {
+      return response.json();
+    }
+    else {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+  }
+}

--- a/app/lib/BdashServerClient.js
+++ b/app/lib/BdashServerClient.js
@@ -9,7 +9,7 @@ export default class BdashServerClient {
   get headers() {
     return {
       'Content-Type': 'application/json',
-      'X-Bdash-API-Token': `token ${this.token}`,
+      'X-Bdash-API-Token': this.token,
       'X-Bdash-API-Version': API_VERSION,
     };
   }

--- a/app/lib/BdashServerClient.js
+++ b/app/lib/BdashServerClient.js
@@ -14,11 +14,11 @@ export default class BdashServerClient {
     };
   }
 
-  async post({ title, body, result, charts }) {
+  async post({ title, body, uuid, result, charts }) {
     let response = await fetch(this.endpoint, {
       method: 'POST',
       headers: this.headers,
-      body: JSON.stringify({ title, body, result, charts }),
+      body: JSON.stringify({ title, body, uuid, result, charts }),
     });
 
     if (response.ok) {

--- a/app/lib/Database/Connection.js
+++ b/app/lib/Database/Connection.js
@@ -9,9 +9,21 @@ export default class Connection {
     return this._db;
   }
 
-  initialize({ databasePath, schema }) {
+  async initialize({ databasePath, schema }) {
     this._db = new sqlite3.Database(databasePath);
-    return this.exec(schema);
+    await this.exec(schema);
+    await this.migrate();
+  }
+
+  async migrate() {
+    // TODO: Improve migration process
+    try {
+      await this.exec('alter table queries add column uuid text');
+    }
+    catch (e) {
+      // do nothing
+      console.log(e);
+    }
   }
 
   exec(sql) {

--- a/app/lib/Database/Query.js
+++ b/app/lib/Database/Query.js
@@ -1,4 +1,5 @@
 import { connection } from './Connection';
+import uuid from 'uuid';
 
 export default class Query {
   static getAll() {
@@ -24,16 +25,21 @@ export default class Query {
       query.rows = query.rows.map(r => Object.values(r));
     }
 
+    if (!query.uuid) {
+      query.uuid = uuid();
+      await this.update(query.id, { uuid: query.uuid });
+    }
+
     return query;
   }
 
   static async create({ title, dataSourceId }) {
     let sql = `
       insert into queries
-      (dataSourceId, title, updatedAt, createdAt)
-      values (?, ?, datetime('now'), datetime('now'))
+      (dataSourceId, title, uuid, updatedAt, createdAt)
+      values (?, ?, ? datetime('now'), datetime('now'))
     `;
-    let id = await connection.insert(sql, dataSourceId, title);
+    let id = await connection.insert(sql, dataSourceId, title, uuid());
 
     return { id, dataSourceId, title };
   }

--- a/app/lib/QuerySharing.js
+++ b/app/lib/QuerySharing.js
@@ -2,6 +2,7 @@ import electron from 'electron';
 import markdownTable from 'markdown-table';
 import csvStringify from 'csv-stringify';
 import GitHubApiClient from './GitHubApiClient';
+import BdashServerClient from './BdashServerClient';
 import Chart from './Chart';
 
 export default {
@@ -40,6 +41,23 @@ export default {
   async copyAsCsv(query) {
     let csv = await getTableDataAsCsv(query);
     return electron.clipboard.writeText(csv);
+  },
+
+  async shareOnBdashServer({ query, chart, setting }) {
+    let [tsv, svg] = await Promise.all([
+      getTableDataAsTsv(query),
+      getChartAsSvg(query, chart),
+    ]);
+
+    let client = new BdashServerClient(setting);
+    let result = await client.post({
+      title: query.title,
+      body: query.body,
+      result: tsv,
+      charts: [svg],
+    });
+
+    electron.shell.openExternal(result.url);
   },
 };
 

--- a/app/lib/QuerySharing.js
+++ b/app/lib/QuerySharing.js
@@ -53,6 +53,7 @@ export default {
     let result = await client.post({
       title: query.title,
       body: query.body,
+      uuid: query.uuid,
       result: tsv,
       charts: [svg],
     });

--- a/app/renderer/components/QueryResultNav/QueryResultNav.js
+++ b/app/renderer/components/QueryResultNav/QueryResultNav.js
@@ -32,6 +32,11 @@ export default class QueryResultNav extends React.Component {
     this.props.onClickShareOnGist();
   }
 
+  handleClickShareOnBdashServer() {
+    this.setState({ openShareFlyout: false });
+    this.props.onClickShareOnBdashServer();
+  }
+
   render() {
     return <div className="QueryResultNav">
       <span
@@ -56,6 +61,7 @@ export default class QueryResultNav extends React.Component {
             <li onClick={() => this.handleClickCopyAsCsv()}>Copy table as CSV</li>
             <li onClick={() => this.handleClickCopyAsMarkdown()}>Copy table as Markdown</li>
             <li onClick={() => this.handleClickShareOnGist()}>Share on gist</li>
+            <li onClick={() => this.handleClickShareOnBdashServer()}>Share on Bdash server</li>
           </ul>
         </Flyout>
       </div>

--- a/app/renderer/pages/Query/Query.js
+++ b/app/renderer/pages/Query/Query.js
@@ -53,6 +53,18 @@ class Query extends React.Component {
     }
   }
 
+  async handleShareOnBdashServer(query) {
+    let chart = this.state.charts.find(chart => chart.queryId === query.id);
+    let setting = this.state.setting.bdashServer;
+
+    try {
+      await QuerySharing.shareOnBdashServer({ query, chart, setting });
+    }
+    catch (err) {
+      alert(err.message);
+    }
+  }
+
   renderMain() {
     let query = this.state.queries.find(query => query.id === this.state.selectedQueryId);
     if (!query) return <div className="page-Query-main" />;
@@ -74,6 +86,7 @@ class Query extends React.Component {
         onClickCopyAsCsv={() => QuerySharing.copyAsCsv(query)}
         onClickCopyAsMarkdown={() => QuerySharing.copyAsMarkdown(query)}
         onClickShareOnGist={() => this.handleShareOnGist(query)}
+        onClickShareOnBdashServer={() => this.handleShareOnBdashServer(query)}
         onSelectTab={name => Action.selectResultTab(query, name)}
         onUpdateChart={Action.updateChart}
         />

--- a/app/renderer/pages/Setting/Setting.js
+++ b/app/renderer/pages/Setting/Setting.js
@@ -20,6 +20,7 @@ class Setting extends React.Component {
     let keyBindOptions = ['default', 'vim'].map(v => ({ value: v, label: v }));
     let setting = this.state.setting;
     let github = setting.github || {};
+    let bdashServer = setting.bdashServer || {};
 
     return <div className="page-Setting">
       <div className="page-Setting-section1">
@@ -48,6 +49,16 @@ class Setting extends React.Component {
         <div className="page-Setting-validateToken">
           <Button onClick={() => Action.validateGithubToken(github)}>Validate Token</Button>
           {this.renderGithubValidateTokenResult()}
+        </div>
+      </div>
+
+      <div className="page-Setting-section1">
+        <h1>Bdash Server Setting</h1>
+        <div className="page-Setting-section2">
+          <h2>Endpoint</h2>
+          <input type="text" onChange={e => Action.update({ bdashServer: { endpoint: e.target.value } })} value={bdashServer.endpoint} />
+          <h2>Token</h2>
+          <input type="text" onChange={e => Action.update({ bdashServer: { token: e.target.value } })} value={bdashServer.token} />
         </div>
       </div>
     </div>;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-select": "^1.0.0-rc.1",
     "sqlite3": "^3.1.7",
     "td": "^0.2.7",
+    "uuid": "^3.0.1",
     "yamljs": "^0.2.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6995,7 +6995,7 @@ uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 


### PR DESCRIPTION
## Problem

Bdash's gist sharing feature is really convenient, but some users have a desire to list, star/like and search queries within the team.

## Idea

Bdash will send a request for sharing query on the defined specification as Bdash API. Any developer can freely implement and launch the server for receiving the sharing query.

Server reference implementation is here(WIP): https://github.com/bdash-app/bdash-server

## Bdash API draft

### Request

```
POST ${setting.endpoint}

X-Bdash-API-Token: ${setting.token} (optinal)
X-Bdash-API-Version: 1

{
  "title": "my query",
  "body": "select * from users where ...",
  "result": "id\tname\tage\n1\tfoo\t30...",
  "charts": ["<svg>...</svg>"]  
}
```

If the server requires user authentication, use a `X-Bdash-API-Token` header.

### Response

```
{ "url": "https://my-bdash-server/queries/100" }
```

Bdash will open the received url in the browser.