### PR TITLE
Remove sort on Group By.

### DIFF
--- a/app/lib/Chart.js
+++ b/app/lib/Chart.js
@@ -55,7 +55,7 @@ export default class Chart {
       });
     }
 
-    let groupValues = _.uniq(this.dataByField(this.params.groupBy)).sort();
+    let groupValues = _.uniq(this.dataByField(this.params.groupBy));
     let idx = this.params.fields.findIndex(field => field === this.params.groupBy);
     let x = _.groupBy(this.params.rows, row => row[idx]);
 


### PR DESCRIPTION
Sorting should be handled exclusively by the user.
The `sort()` that is currently applied has undesirable side effects.

Example of a chart that displays as expected:

<img width="1449" alt="cat_id" src="https://user-images.githubusercontent.com/3770424/31067194-30e67dfa-a717-11e7-91e6-0e8b2d1adfdb.png">


Same query but the "Group By" field has changed. An alphabetical sort is applied on the dates:

<img width="1349" alt="cat_name" src="https://user-images.githubusercontent.com/3770424/31067199-351cf304-a717-11e7-95d5-a0241c8ca3a7.png">


Removing the sort solves the problem.
Note: I haven't thought about possible side effects or use cases where the sort might be needed.

Signed-off-by: Maxime Legaignoux <maxime.lgx@gmail.com>