### PR TITLE
Indent selection on default mode

### DIFF
--- a/src/renderer/components/Editor/Editor.tsx
+++ b/src/renderer/components/Editor/Editor.tsx
@@ -33,7 +33,10 @@ export default class Editor extends React.Component<any, any> {
         this.codeMirror.execCommand("selectAll");
       },
       Tab: cm => {
-        if (!cm.state.vim || cm.state.vim.insertMode) {
+        if (!cm.state.vim) {
+          if (cm.somethingSelected()) cm.indentSelection("add");
+          else cm.execCommand("insertSoftTab");
+        } else if (cm.state.vim.insertMode) {
           cm.execCommand("insertSoftTab");
         }
       }


### PR DESCRIPTION
When I was selecting codes and then I pushed down Tab, code selection is replaced to softtab.
I expected to indent code selection that is CodeMirror default behavior. 

Original implementation see here: https://github.com/codemirror/CodeMirror/blob/ed8dfeb5e2ed25b5dd1f1eccc7b757ca6dbd118d/src/edit/commands.js#L106-L109

So, I changed this behavior. what do you think?

| before | after |
| --- | --- |
| ![20180904080124_img20180904-16-1y7uici](https://user-images.githubusercontent.com/6443461/45018183-702cc300-b064-11e8-87a7-7a94f603663b.gif) | ![20180904080254_img20180904-19-zm9ulc](https://user-images.githubusercontent.com/6443461/45018184-728f1d00-b064-11e8-806a-1fefb2fb2794.gif) |