### PR TITLE
Make it copyable on Linux

### DIFF
--- a/src/renderer/components/Editor/Editor.tsx
+++ b/src/renderer/components/Editor/Editor.tsx
@@ -51,6 +51,9 @@ export default class Editor extends React.Component<any, any> {
       action: "delLineLeft",
       context: "insert"
     });
+    if (process.platform !== "darwin") {
+      (CodeMirror.Vim as any).unmap("<C-c>");
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Problem
===

Copying query to OS clipboard is impossible on Linux while using Vim keybind.

I guess it has the same problem on Windows, but I don't have Windows machine, so I'm not sure.
By the way, it works well on macOS :apple:

Cause
===

The Vim keybind overrides `<C-c>`. In Vim, `<C-c>` works as `<Esc>` almost, so CodeMirror maps `<C-c>` to `<Esc>`.

https://github.com/codemirror/CodeMirror/blob/be9d254ecc708563727d1f4198383af660b32080/keymap/vim.js#L62-L65

It conceals OS keybind, so Linux user cannot copy query.



Solution
===

Unmap `<C-c>` except darwin.

I think copying is more important than `<Esc>`.
Because we can use other keys to leave insert mode instead of `<C-c>`. For example, `<C-[>` and `<Esc>`. But we do not have any alternative keys for copying.

Personally I think Vimmer does not use `<C-c>` on Vim usually, because it has a behaviour different from `<Esc>`, and `<Esc>` is better in most cases.

Note
===


I found an issue that is about the same problem on the CodeMirror repository. https://github.com/codemirror/CodeMirror/issues/3075

