### PR TITLE
Use title as file names to be shared on gist

### DIFF
--- a/src/lib/QuerySharing.ts
+++ b/src/lib/QuerySharing.ts
@@ -21,14 +21,15 @@ export default {
       ## Created by
       [Bdash](https://github.com/bdash-app/bdash)
     `);
+    const fileNamePrefix = query.title !== "" ? query.title : "bdash";
     const files = {
-      "bdash.sql": { content: query.body },
-      "bdash_01.tsv": { content: tsv },
-      "bdash_03.md": { content: infoMd }
+      [`${fileNamePrefix}.sql`]: { content: query.body },
+      [`${fileNamePrefix}_01.tsv`]: { content: tsv },
+      [`${fileNamePrefix}_03.md`]: { content: infoMd }
     };
 
     if (svg) {
-      files["bdash_02.svg"] = { content: svg };
+      files[`${fileNamePrefix}_02.svg`] = { content: svg };
     }
 
     const client = new GitHubApiClient(setting);


### PR DESCRIPTION
## Problem
All files are shared on gist with the same names. They are difficult to distinguish in the list.

<img src="https://user-images.githubusercontent.com/1413408/51677472-1d58a580-201d-11e9-8b77-ec8c9ba71499.png" width="200"/>

## Solution
Use `query.title` as a file names prefix.