### PR TITLE
Add the feature to toggle comment by Cmd or Ctrl + /

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -4,7 +4,7 @@ import isDev from "electron-is-dev";
 
 const editMenu: Electron.MenuItemConstructorOptions = {
   label: "Edit",
-  submenu: [{ role: "cut" }, { role: "copy" }, { role: "paste" }, { role: "selectall" }, { type: "separator" }, { label: "Toggle Comment", accelerator: "CommandOrControl+/" },],
+  submenu: [{ role: "cut" }, { role: "copy" }, { role: "paste" }, { role: "selectall" }]
 };
 
 const viewMenu: Electron.MenuItemConstructorOptions = {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -4,7 +4,7 @@ import isDev from "electron-is-dev";
 
 const editMenu: Electron.MenuItemConstructorOptions = {
   label: "Edit",
-  submenu: [{ role: "cut" }, { role: "copy" }, { role: "paste" }, { role: "selectall" }]
+  submenu: [{ role: "cut" }, { role: "copy" }, { role: "paste" }, { role: "selectall" }, { type: "separator" }, { label: "Toggle Comment", accelerator: "CommandOrControl+/" },],
 };
 
 const viewMenu: Electron.MenuItemConstructorOptions = {

--- a/src/renderer/components/Editor/Editor.tsx
+++ b/src/renderer/components/Editor/Editor.tsx
@@ -34,7 +34,6 @@ export default class Editor extends React.Component<any, any> {
         this.codeMirror.execCommand("selectAll");
       },
       [process.platform === "darwin" ? "Cmd-/" : "Ctrl-/"]: () => {
-        console.log("toggleComment");
         this.codeMirror.execCommand("toggleComment");
       },
       Tab: cm => {

--- a/src/renderer/components/Editor/Editor.tsx
+++ b/src/renderer/components/Editor/Editor.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import CodeMirror from "codemirror";
+import "codemirror/addon/comment/comment";
 import "codemirror/addon/search/search";
 import "codemirror/addon/runmode/colorize";
 import "codemirror/keymap/vim";
@@ -31,6 +32,10 @@ export default class Editor extends React.Component<any, any> {
       },
       [process.platform === "darwin" ? "Cmd-A" : "Ctrl-A"]: () => {
         this.codeMirror.execCommand("selectAll");
+      },
+      [process.platform === "darwin" ? "Cmd-/" : "Ctrl-/"]: () => {
+        console.log("toggleComment");
+        this.codeMirror.execCommand("toggleComment");
       },
       Tab: cm => {
         if (!cm.state.vim) {


### PR DESCRIPTION
We can use shortcut toggle comment(s) in Editor.
https://codemirror.net/doc/manual.html (Search this page with "toggleComment")

~Note: MenuItem "Toggle Comment" do nothing works.
I need to use ipcMain to main process communicate with render process, I give up because it is difficult.
https://electronjs.org/docs/api/ipc-main
https://github.com/electron/electron/blob/v2.0.0/docs/api/ipc-main.md
(If you have a certain plan to communicate between main/renderer processes, I can program it.)~