### PR TITLE
Change pie chart direction to clockwise

### DIFF
--- a/src/lib/Chart.ts
+++ b/src/lib/Chart.ts
@@ -127,6 +127,7 @@ export default class Chart {
     return [
       {
         type: "pie",
+        direction: "clockwise",
         labels: this.dataByField(this.params.x),
         values: this.dataByField(this.params.y[0])
       }


### PR DESCRIPTION
A pie chart is usually clockwise.
But default direction of plotly.js is counter-clockwise.
https://plot.ly/javascript/reference/#pie-direction

I suggest Bdash use clockwise.

# Screenshots

## Before

<img width="600" alt="clockwise" src="https://user-images.githubusercontent.com/1213991/68383589-4b1c6e80-0199-11ea-948a-ae39b0f40d76.png">

## After

<img width="600" alt="スクリーンショット 2019-11-07 19 57 08" src="https://user-images.githubusercontent.com/1213991/68383626-5a032100-0199-11ea-8570-3038ed4572b1.png">