### PR TITLE
Fix mysql query executor in no field result

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "watch": "webpack --watch",
     "test": "yarn run test:unit && yarn run test:integration",
     "test:unit": "electron-mocha --grep @remote --invert \"./test/unit/**/*.test.{ts,tsx}\"",
+    "test:unit:remote": "electron-mocha --grep @remote \"./test/unit/**/*.test.{ts,tsx}\"",
     "test:build": "webpack --env.BUILD_ENV=test && electron-builder build --config electron-builder.test.yml --publish never --dir",
     "test:integration": "yarn run test:build && mocha --exit test/integration/test.ts",
     "lint": "yarn run lint:eslint && yarn run lint:tsc && yarn run lint:prettier",

--- a/src/lib/DataSourceDefinition/Mysql.ts
+++ b/src/lib/DataSourceDefinition/Mysql.ts
@@ -85,6 +85,8 @@ export default class Mysql extends Base {
             reject(err);
           } else if (fields && rows) {
             resolve({ fields: fields.map(f => f.name), rows });
+          } else if (rows) {
+            resolve({ fields: [], rows: [] });
           } else {
             // cancel query does not have result
             resolve();

--- a/test/unit/lib/DataSourceDefinition/Mysql.test.ts
+++ b/test/unit/lib/DataSourceDefinition/Mysql.test.ts
@@ -18,6 +18,14 @@ suite("DataSourceDefinition/Mysql @remote", () => {
     });
   });
 
+  test("insert", async () => {
+    const result = await new Mysql(config).execute("insert into test values (4, 'hoge')");
+    assert.deepStrictEqual(result, {
+      fields: [],
+      rows: []
+    });
+  });
+
   test("update", async () => {
     const result = await new Mysql(config).execute("update test set text = 'hoge'");
     assert.deepStrictEqual(result, {

--- a/test/unit/lib/DataSourceDefinition/Mysql.test.ts
+++ b/test/unit/lib/DataSourceDefinition/Mysql.test.ts
@@ -10,11 +10,27 @@ suite("DataSourceDefinition/Mysql @remote", () => {
     await initialize();
   });
 
-  test("execute", async () => {
+  test("select", async () => {
     const result = await new Mysql(config).execute("select id, text from test order by id");
     assert.deepStrictEqual(result, {
       fields: ["id", "text"],
       rows: [[1, "foo"], [2, "bar"], [3, "baz"]]
+    });
+  });
+
+  test("update", async () => {
+    const result = await new Mysql(config).execute("update test set text = 'hoge'");
+    assert.deepStrictEqual(result, {
+      fields: [],
+      rows: []
+    });
+  });
+
+  test("delete", async () => {
+    const result = await new Mysql(config).execute("delete from test where id = 1");
+    assert.deepStrictEqual(result, {
+      fields: [],
+      rows: []
     });
   });
 

--- a/test/unit/lib/DataSourceDefinition/Postgres.test.ts
+++ b/test/unit/lib/DataSourceDefinition/Postgres.test.ts
@@ -18,6 +18,14 @@ suite("DataSourceDefinition/Postgres @remote", () => {
     });
   });
 
+  test("insert", async () => {
+    const result = await new Postgres(config).execute("insert into test values (4, 'hoge')");
+    assert.deepStrictEqual(result, {
+      fields: [],
+      rows: []
+    });
+  });
+
   test("update", async () => {
     const result = await new Postgres(config).execute("update test set text = 'hoge'");
     assert.deepStrictEqual(result, {

--- a/test/unit/lib/DataSourceDefinition/Postgres.test.ts
+++ b/test/unit/lib/DataSourceDefinition/Postgres.test.ts
@@ -10,11 +10,27 @@ suite("DataSourceDefinition/Postgres @remote", () => {
     await initialize();
   });
 
-  test("execute", async () => {
+  test("select", async () => {
     const result = await new Postgres(config).execute("select id, text from test order by id");
     assert.deepStrictEqual(result, {
       fields: ["id", "text"],
       rows: [["1", "foo"], ["2", "bar"], ["3", "baz"]]
+    });
+  });
+
+  test("update", async () => {
+    const result = await new Postgres(config).execute("update test set text = 'hoge'");
+    assert.deepStrictEqual(result, {
+      fields: [],
+      rows: []
+    });
+  });
+
+  test("delete", async () => {
+    const result = await new Postgres(config).execute("delete from test where id = 1");
+    assert.deepStrictEqual(result, {
+      fields: [],
+      rows: []
     });
   });
 


### PR DESCRIPTION
Fix a bug which progress circle displayed externally when execute queries return empty fields in Mysql. (e.g. `update`, `delete`, etc…)

And I added an entry point to execute tests which require DB and also test cases in Mysql and Postgres.