### PR TITLE
Support CircleCI DB integrated test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,33 @@ jobs:
   test:
     working_directory: ~/workspace
     docker:
-      - image: circleci/node:8.9.4-browsers
+      - image: circleci/node:10-browsers
+      - image: circleci/postgres:12-alpine-ram
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_DB: bdash_test
+      - image: circleci/mysql:5.7-ram
+        environment:
+          MYSQL_ROOT_PASSWORD: ""
+          MYSQL_DATABASE: bdash_test
+          MYSQL_USER: circleci
+          MYSQL_PASSWORD: password
+    environment:
+      POSTGRES_USER: circleci
+      MYSQL_USER: root
     steps:
       - checkout
+      - run: sudo apt-get update
+      - run: sudo apt -y install gnupg2
+      - run: wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+      - run: echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |sudo tee  /etc/apt/sources.list.d/pgdg.list
+      - run: sudo apt update
+      - run: sudo apt-get install postgresql-client-12 default-mysql-client
       - restore_cache:
           key: dependency-cache-{{ checksum "yarn.lock" }}
       - run: yarn install
       - run: yarn run ci
+      - run: yarn run test:unit:remote
       - save_cache:
           key: dependency-cache-{{ checksum "yarn.lock" }}
           paths:


### PR DESCRIPTION
Setup `test:unit:remote` in CircleCI.
Sample https://circleci.com/gh/mtgto/bdash/2

I have not permission to use CircleCI as Pull Request CI, please configure after merge it.
Document for integration DB: https://circleci.com/docs/2.0/postgres-config/