### PR TITLE
Fix height of menu items and header

### DIFF
--- a/src/renderer/components/GlobalMenu/GlobalMenu.css
+++ b/src/renderer/components/GlobalMenu/GlobalMenu.css
@@ -10,6 +10,7 @@
   padding: 12px 0;
   font-size: 22px;
   cursor: pointer;
+  height: 26px;
 }
 
 .GlobalMenu-item:hover {

--- a/src/renderer/components/QueryHeader/QueryHeader.css
+++ b/src/renderer/components/QueryHeader/QueryHeader.css
@@ -11,6 +11,7 @@
   border: none;
   font-family: inherit;
   width: 100%;
+  height: 28px;
 }
 
 .QueryHeader-selectDataSource {


### PR DESCRIPTION
Master (Electron 7) changes the height of menu items and editor header.
(menu item is not regular square. editor header overlaps editor.)

![image](https://user-images.githubusercontent.com/1213991/70804923-08366200-1dfb-11ea-9a73-bf9865bcaf74.png)

I don't know why it changes, maybe the difference of Chromium version.

I set the height of changed elements.

<img width="1280" alt="after" src="https://user-images.githubusercontent.com/1213991/70805045-5ea3a080-1dfb-11ea-8e00-3c3085976d92.png">
