### PR TITLE
Fix devtool config to enable source map

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const nodeExternals = require("webpack-node-externals");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
-module.exports = env => {
+module.exports = (env, argv) => {
   const buildEnv = (env && env.BUILD_ENV) || "development";
   const isDevelopment = buildEnv === "development";
   const appDir = path.join(__dirname, "app", buildEnv);
@@ -27,7 +27,7 @@ module.exports = env => {
 
   const commonConfig = {
     resolve: { extensions: [".ts", ".tsx"] },
-    devtool: "source-map",
+    devtool: argv.mode === "production" ? "inline-source-map" : "eval-source-map",
     node: {
       __dirname: false,
       __filename: false


### PR DESCRIPTION
Since updated to Electron 7, source map doesn't works.
(Source tab doesn't have any src files in Chromium devtools...)

Because `devtool: "sourcemap"` doesn't works in current Chromium.

https://github.com/webpack/webpack/issues/8506
https://bugs.chromium.org/p/chromium/issues/detail?id=919575

This problem remains unresolved.

### Use "eval-source-map" in development environment

To solve, use "eval-source-map".
It can compile fast.

https://webpack.js.org/configuration/devtool/

But it contains "webpack-inline:///..." (it is compiled code even if filename is "*.ts" or "*.tsx")

<img width="800" alt="eval-source-map" src="https://user-images.githubusercontent.com/1213991/70856335-103af280-1f1e-11ea-9f1f-b2489e4a5b25.png">

### Use "inline-source-map" in production

"tsx" loses color syntax, but we can debug like breakpoints.
Same users exist, but no answer.

https://github.com/electron/electron/issues/20504

<img width="1349" alt="inline-source-map" src="https://user-images.githubusercontent.com/1213991/70856390-3f059880-1f1f-11ea-9ce4-e1cd908a8e3e.png">
