### PR TITLE
Add the feature to simple DB migration

### DIFF
--- a/src/lib/Database/Connection.ts
+++ b/src/lib/Database/Connection.ts
@@ -1,5 +1,5 @@
 import sqlite3 from "sqlite3";
-import schema from "./schema";
+import { migrations, Migration } from "./schema";
 
 export default class Connection {
   _db: any;
@@ -12,9 +12,46 @@ export default class Connection {
     return this._db;
   }
 
-  initialize({ databasePath }) {
+  async initialize({ databasePath }): Promise<void> {
     this._db = new sqlite3.Database(databasePath);
-    return this.exec(schema);
+    await this.migrate(migrations);
+  }
+
+  async migrate(migrations: Migration[]): Promise<void> {
+    await this.exec('begin;');
+    try {
+      await this.exec(
+        `create table if not exists schema_version (
+            version integer primary key
+        );`
+      );
+      const current_version: number = await this.get(`select version from schema_version`).then(
+        async (row: { version: number } | undefined) => {
+          if (row) {
+            return row.version;
+          } else {
+            await this.exec(`insert into schema_version(version) values (0);`);
+            return 0;
+          }
+        }
+      );
+
+      let last_version: number = 0;
+      for (const m of migrations) {
+        if (m.version <= last_version) {
+          throw new Error(`Wrong migration script: version ${m.version}`);
+        }
+        if (m.version > current_version) {
+          await this.exec(m.query);
+          await this.run(`update schema_version set version = ?`, m.version);
+        }
+        last_version = m.version;
+      }
+      await this.exec('commit;');
+    } catch (err) {
+      await this.exec('rollback;');
+      throw err;
+    }
   }
 
   exec(sql): Promise<any> {

--- a/src/lib/Database/Connection.ts
+++ b/src/lib/Database/Connection.ts
@@ -18,7 +18,7 @@ export default class Connection {
   }
 
   async migrate(migrations: Migration[]): Promise<void> {
-    await this.exec('begin;');
+    await this.exec("begin;");
     try {
       await this.exec(
         `create table if not exists schema_version (
@@ -47,9 +47,9 @@ export default class Connection {
         }
         last_version = m.version;
       }
-      await this.exec('commit;');
+      await this.exec("commit;");
     } catch (err) {
-      await this.exec('rollback;');
+      await this.exec("rollback;");
       throw err;
     }
   }

--- a/src/lib/Database/schema.ts
+++ b/src/lib/Database/schema.ts
@@ -1,7 +1,7 @@
 export type Migration = {
   readonly version: number;
   readonly query: string;
-}
+};
 
 export const migrations: Migration[] = [
   {
@@ -43,6 +43,6 @@ export const migrations: Migration[] = [
       updatedAt datetime not null
     );
     create index if not exists idx_query_id_on_charts on charts(queryId);
-    `,
+    `
   }
 ];

--- a/src/lib/Database/schema.ts
+++ b/src/lib/Database/schema.ts
@@ -1,40 +1,48 @@
-const schema = `
-create table if not exists data_sources (
-  id integer primary key autoincrement,
-  name text not null,
-  type text not null,
-  config json not null,
-  createdAt datetime not null,
-  updatedAt datetime not null
-);
+export type Migration = {
+  readonly version: number;
+  readonly query: string;
+}
 
-create table if not exists queries (
-  id integer primary key autoincrement,
-  dataSourceId integer not null references data_sources(id),
-  title text not null,
-  body text not null default '',
-  runtime integer,
-  status text check(status in ('success', 'failure')),
-  fields json,
-  rows json,
-  errorMessage text,
-  runAt datetime,
-  createdAt datetime not null,
-  updatedAt datetime not null
-);
-
-create table if not exists charts (
-  id integer primary key autoincrement,
-  queryId integer not null references queries(id) on delete cascade,
-  type text not null,
-  xColumn text,
-  yColumns json,
-  groupColumn text,
-  stacking boolean not null default 0,
-  createdAt datetime not null,
-  updatedAt datetime not null
-);
-create index if not exists idx_query_id_on_charts on charts(queryId);
-`;
-
-export default schema;
+export const migrations: Migration[] = [
+  {
+    version: 1,
+    query: `
+    create table if not exists data_sources (
+      id integer primary key autoincrement,
+      name text not null,
+      type text not null,
+      config json not null,
+      createdAt datetime not null,
+      updatedAt datetime not null
+    );
+    
+    create table if not exists queries (
+      id integer primary key autoincrement,
+      dataSourceId integer not null references data_sources(id),
+      title text not null,
+      body text not null default '',
+      runtime integer,
+      status text check(status in ('success', 'failure')),
+      fields json,
+      rows json,
+      errorMessage text,
+      runAt datetime,
+      createdAt datetime not null,
+      updatedAt datetime not null
+    );
+    
+    create table if not exists charts (
+      id integer primary key autoincrement,
+      queryId integer not null references queries(id) on delete cascade,
+      type text not null,
+      xColumn text,
+      yColumns json,
+      groupColumn text,
+      stacking boolean not null default 0,
+      createdAt datetime not null,
+      updatedAt datetime not null
+    );
+    create index if not exists idx_query_id_on_charts on charts(queryId);
+    `,
+  }
+];

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -7,6 +7,12 @@ import Bdash from "../lib/Bdash";
 import "./components/SplashScreen";
 import App from "./pages/App";
 
-Bdash.initialize().then(() => {
-  ReactDOM.render(<App />, document.getElementById("app"));
-});
+Bdash.initialize()
+  .then(() => {
+    ReactDOM.render(<App />, document.getElementById("app"));
+  })
+  .catch((err: Error) => {
+    // TODO: process exit after close alert
+    alert(err.message);
+    throw err;
+  });

--- a/test/helpers/DatabaseHelper.ts
+++ b/test/helpers/DatabaseHelper.ts
@@ -1,7 +1,7 @@
 import { connection } from "../../src/lib/Database/Connection";
 
 export default class DatabaseHelper {
-  static initialize() {
+  static initialize(): Promise<void> {
     return connection.initialize({ databasePath: ":memory:" });
   }
 }

--- a/test/unit/lib/Database/Connection.test.ts
+++ b/test/unit/lib/Database/Connection.test.ts
@@ -1,0 +1,79 @@
+import assert from "assert";
+import Connection from "../../../../src/lib/Database/Connection";
+
+suite("Database/Connection", () => {
+  suite("migrate", () => {
+    test("execute migration", async () => {
+      const connection = new Connection();
+      await connection.initialize({ databasePath: ":memory:" });
+      await connection.migrate([
+        {
+          version: 1000000000,
+          query: "select 1"
+        }
+      ]);
+    });
+
+    test("should not execute already executed migration", async () => {
+      const connection = new Connection();
+      await connection.initialize({ databasePath: ":memory:" });
+      try {
+        await connection.migrate([
+          {
+            version: 0,
+            query: "select 1"
+          }
+        ]);
+        assert.fail();
+      } catch (err) {
+        // do nothing
+      }
+    });
+
+    test("should not two migrations which have same version", async () => {
+      const connection = new Connection();
+      await connection.initialize({ databasePath: ":memory:" });
+      try {
+        await connection.migrate([
+          {
+            version: 1000000000,
+            query: "select 1"
+          },
+          {
+            version: 1000000000,
+            query: "select 1"
+          }
+        ]);
+        assert.fail();
+      } catch (err) {
+        // do nothing
+      }
+    });
+
+    test("rollback when error occur", async () => {
+      const connection = new Connection();
+      await connection.initialize({ databasePath: ":memory:" });
+      try {
+        await connection.migrate([
+          {
+            version: 1000000000,
+            query: "create table test_aaa(id integer);"
+          },
+          {
+            version: 1000000001,
+            query: "insert into test_aaa values(0);"
+          },
+          {
+            version: 1000000002,
+            query: "broken sql"
+          }
+        ]);
+        assert.fail();
+      } catch (err) {
+        connection.get("select * from test_aaa;").then(() => assert.fail()).catch(() => {
+          // do nothing
+        });
+      }
+    });
+  });
+});

--- a/test/unit/lib/Database/Connection.test.ts
+++ b/test/unit/lib/Database/Connection.test.ts
@@ -70,9 +70,12 @@ suite("Database/Connection", () => {
         ]);
         assert.fail();
       } catch (err) {
-        connection.get("select * from test_aaa;").then(() => assert.fail()).catch(() => {
-          // do nothing
-        });
+        connection
+          .get("select * from test_aaa;")
+          .then(() => assert.fail())
+          .catch(() => {
+            // do nothing
+          });
       }
     });
   });


### PR DESCRIPTION
- Use `user_version` in sqlite3 db to manage db schema version.
- On start up, migrate db if latest version is larger than current version.
