### PR TITLE
Fix color syntax of tsx in devtools

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import electron from "electron";
+import electron, { session } from "electron";
 import { updater } from "./updater";
 import { initMenu } from "./menu";
 import logger from "./logger";
@@ -38,6 +38,18 @@ app.on("window-all-closed", () => {
 });
 
 app.on("ready", () => {
+  // https://github.com/electron/electron/issues/13008#issuecomment-569363295
+  session.defaultSession.webRequest.onBeforeRequest((details, callback) => {
+    const redirectURL = details.url.replace(
+      /^devtools:\/\/devtools\/remote\/serve_file\/@[0-9a-f]{40}\//,
+      "https://chrome-devtools-frontend.appspot.com/serve_file/@675968a8c657a3bd9c1c2c20c5d2935577bbc5e6/"
+    );
+    if (redirectURL !== details.url) {
+      callback({ redirectURL });
+    } else {
+      callback({});
+    }
+  });
   createWindow();
   updater.watch();
   initMenu();


### PR DESCRIPTION
For detail, see https://github.com/electron/electron/issues/13008#issuecomment-569363295

In short:

- devtools uses CodeMirror to enable color syntax of jsx files
- devtools loads CodeMirror modules from Google server on demands
- If URL scheme is "devtools://",  dynamic loading failed in Electron (maybe Electron's bug)

Until Electron fix this problem, we need to rewrite request.