### PR TITLE
Fix graph of gist is not work

### DIFF
--- a/src/lib/Chart.ts
+++ b/src/lib/Chart.ts
@@ -37,9 +37,10 @@ export default class Chart {
     // width, height are default of plotly.js
     // https://plot.ly/javascript/reference/#layout-width
     // https://plot.ly/javascript/reference/#layout-height
-    return Plotly.toImage(gd, { format: "svg", width: 700, height: 450 }).then(svg =>
-      svg.replace(/"Open Sans"/g, "'Open Sans'")
-    );
+    return Plotly.toImage(gd, { format: "svg", width: 700, height: 450 }).then(svg => {
+      const dataURI = decodeURIComponent(svg);
+      return dataURI.substr(dataURI.indexOf(",")+1).replace(/"Open Sans"/g, "'Open Sans'");
+    });
   }
 
   getData(): Partial<Plotly.PlotData>[] {

--- a/src/lib/Chart.ts
+++ b/src/lib/Chart.ts
@@ -39,7 +39,7 @@ export default class Chart {
     // https://plot.ly/javascript/reference/#layout-height
     return Plotly.toImage(gd, { format: "svg", width: 700, height: 450 }).then(svg => {
       const dataURI = decodeURIComponent(svg);
-      return dataURI.substr(dataURI.indexOf(",")+1).replace(/"Open Sans"/g, "'Open Sans'");
+      return dataURI.substr(dataURI.indexOf(",") + 1).replace(/"Open Sans"/g, "'Open Sans'");
     });
   }
 

--- a/src/lib/Chart.ts
+++ b/src/lib/Chart.ts
@@ -34,7 +34,10 @@ export default class Chart {
     }
 
     const gd = await Plotly.plot(div, data, layout);
-    return Plotly.toImage(gd, { format: "svg", width: layout.width!, height: layout.height! }).then(svg =>
+    // width, height are default of plotly.js
+    // https://plot.ly/javascript/reference/#layout-width
+    // https://plot.ly/javascript/reference/#layout-height
+    return Plotly.toImage(gd, { format: "svg", width: 700, height: 450 }).then(svg =>
       svg.replace(/"Open Sans"/g, "'Open Sans'")
     );
   }


### PR DESCRIPTION
Fix graph is corrupt since #76

- Use default width, height from default size of plotly.js
- Decode data URI (Plotly.toImage encode as data uri)