### PR TITLE
Update sqlite3 to v4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-micro-flyout": "1.0.1",
     "react-modal": "3.1.10",
     "react-select": "~3.0.8",
-    "sqlite3": "4.1.0",
+    "sqlite3": "~4.1.1",
     "td": "0.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6735,10 +6735,10 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-sqlite3@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.1.0.tgz#e051fb9c133be15726322a69e2e37ec560368380"
-  integrity sha512-RvqoKxq+8pDHsJo7aXxsFR18i+dU2Wp5o12qAJOV5LNcDt+fgJsc2QKKg3sIRfXrN9ZjzY1T7SNe/DFVqAXjaw==
+sqlite3@~4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.1.1.tgz#539a42e476640796578e22d589b3283c28055242"
+  integrity sha512-CvT5XY+MWnn0HkbwVKJAyWEMfzpAPwnTiB3TobA5Mri44SrTovmmh499NPQP+gatkeOipqPlBLel7rn4E/PCQg==
   dependencies:
     nan "^2.12.1"
     node-pre-gyp "^0.11.0"


### PR DESCRIPTION
sqlite3 v4.1.1 provides prebuild binary for Electron v7.1.
https://github.com/mapbox/node-sqlite3/blob/master/CHANGELOG.md#411