### PR TITLE
Fix the order of figures on gist

### DIFF
--- a/src/lib/QuerySharing.ts
+++ b/src/lib/QuerySharing.ts
@@ -38,12 +38,12 @@ export default {
     const fileNamePrefix = query.title !== "" ? query.title.replace(/[/\s]/g, "_") : "bdash";
     const files = {
       [`${fileNamePrefix}.sql`]: { content: query.body },
-      [`${fileNamePrefix}_01.tsv`]: { content: tsv },
+      [`${fileNamePrefix}_02.tsv`]: { content: tsv },
       [`${fileNamePrefix}_03.md`]: { content: infoMd }
     };
 
     if (svg) {
-      files[`${fileNamePrefix}_02.svg`] = { content: svg };
+      files[`${fileNamePrefix}_01.svg`] = { content: svg };
     }
 
     const client = new GitHubApiClient(setting);


### PR DESCRIPTION
Fix #67

Example: https://gist.github.com/mtgto/ef67b1d65ef5406388df1e92bb822d4c