### PR TITLE
Fix lint:prettier in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "lint": "yarn run lint:eslint && yarn run lint:tsc && yarn run lint:prettier",
     "lint:eslint": "eslint --ext '.js,.jsx,.ts,.tsx' .",
     "lint:tsc": "tsc --noEmit",
-    "lint:prettier": "prettier --list-different ./**/*.{js,jsx,ts,tsx,css,json}",
-    "format": "prettier --write '**/*.{js,jsx,ts,tsx,css,json}'",
+    "lint:prettier": "prettier --list-different './**/*.{js,jsx,ts,tsx,css,json}'",
+    "format": "prettier --write './**/*.{js,jsx,ts,tsx,css,json}'",
     "publish": "webpack --env.BUILD_ENV=production --mode=production && electron-builder build --publish always",
     "ci": "yarn run lint && yarn run test"
   },

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "lint": "yarn run lint:eslint && yarn run lint:tsc && yarn run lint:prettier",
     "lint:eslint": "eslint --ext '.js,.jsx,.ts,.tsx' .",
     "lint:tsc": "tsc --noEmit",
-    "lint:prettier": "prettier --list-different './**/*.{js,jsx,ts,tsx,css,json}'",
-    "format": "prettier --write './**/*.{js,jsx,ts,tsx,css,json}'",
+    "lint:prettier": "prettier --list-different \"./**/*.{js,jsx,ts,tsx,css,json}\"",
+    "format": "prettier --write \"./**/*.{js,jsx,ts,tsx,css,json}\"",
     "publish": "webpack --env.BUILD_ENV=production --mode=production && electron-builder build --publish always",
     "ci": "yarn run lint && yarn run test"
   },


### PR DESCRIPTION
I finally found the reason why my `lint:prettier` found nothing, but CI finds prettier warning.