### PR TITLE
Use <i> instead of pseudo element

### DIFF
--- a/src/renderer/components/TableList/TableList.css
+++ b/src/renderer/components/TableList/TableList.css
@@ -10,10 +10,7 @@
   position: relative;
 }
 
-.TableList-filter:before {
-  content: "\f002";
-  font-family: "FontAwesome";
-  display: inline-block;
+.TableList-filter > i {
   position: absolute;
   left: 14px;
   top: 16px;

--- a/src/renderer/components/TableList/TableList.tsx
+++ b/src/renderer/components/TableList/TableList.tsx
@@ -48,6 +48,7 @@ export default class TableList extends React.Component<Props> {
     return (
       <div className="TableList">
         <div className="TableList-filter">
+          <i className="fas fa-search" />
           <input type="search" value={dataSource.tableFilter} onChange={e => this.handleChangeTableFilter(e)} />
         </div>
         <ul>{items}</ul>


### PR DESCRIPTION
The font name was changed in FontAwesome 5, so it could not be displayed.

## before
<img width="266" alt="Screen Shot 2020-02-10 at 22 37 46" src="https://user-images.githubusercontent.com/39471/74154728-86c24b00-4c56-11ea-84d5-696c485f9eef.png">

## after
<img width="267" alt="Screen Shot 2020-02-10 at 22 37 29" src="https://user-images.githubusercontent.com/39471/74154727-8629b480-4c56-11ea-946a-58fd52dd3694.png">

FYI @mtgto 