### PR TITLE
Fix to enable to clear the value of group by

### DIFF
--- a/src/renderer/components/QueryResultChart/QueryResultChart.tsx
+++ b/src/renderer/components/QueryResultChart/QueryResultChart.tsx
@@ -189,6 +189,7 @@ export default class QueryResultChart extends React.Component<Props> {
               options={fieldOptions}
               value={currentGroupOption}
               onChange={o => this.handleChangeGroup(o)}
+              isClearable={true}
               styles={selectStyles}
             />
           </div>


### PR DESCRIPTION
Since #73, user cannot clear "Group By" selectbox.