### PR TITLE
Update to Electron v7.1.12

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,5 +1,5 @@
 save-exact true
-disturl "https://atom.io/download/electron"
-target "7.1.2"
+disturl "https://electronjs.org/headers"
+target "7.1.12"
 runtime "electron"
 build-from-source true

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "clean-webpack-plugin": "0.1.19",
     "copy-webpack-plugin": "4.5.1",
     "css-loader": "0.28.8",
-    "electron": "7.1.2",
+    "electron": "7.1.12",
     "electron-builder": "21.2.0",
     "electron-mocha": "6.0.1",
     "electron-publisher-s3": "20.14.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,6 @@ module.exports = (env, argv) => {
 
   const commonConfig = {
     resolve: { extensions: [".ts", ".tsx"] },
-    devtool: argv.mode === "production" ? "inline-source-map" : "eval-source-map",
     node: {
       __dirname: false,
       __filename: false
@@ -38,6 +37,7 @@ module.exports = (env, argv) => {
 
   const mainConfig = Object.assign(
     {
+      devtool: false,
       target: "electron-main",
       entry: "./src/main/index.ts",
       output: {
@@ -59,6 +59,7 @@ module.exports = (env, argv) => {
 
   const rendererConfig = Object.assign(
     {
+      devtool: argv.mode === "production" ? "inline-source-map" : "eval-source-map",
       target: "electron-renderer",
       entry: "./src/renderer/app.tsx",
       output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,10 +2449,10 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-7.1.2.tgz#d1726b9e50b29e97f5f12b52feb225ba87e0640f"
-  integrity sha512-7hjONYt2GlQfKuKgQrhhUL1P9lbGWLBfMUq+2QFU3yeLtCvM0ROfPJCRP4OF5pVp3KDyfFp4DtmhuVzAnxV3jA==
+electron@7.1.12:
+  version "7.1.12"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-7.1.12.tgz#7a9a416975f466b941c8ef1a48c5a50aefad494f"
+  integrity sha512-gOJxAlJX2UyCRRncKzKzHSZStDI6MdoDzsustTCzudoZx3vlst1kkIP0n5t3TWTNoKNY/ihRsYIpeu63ar1m/g==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
- Update Electron v7.1.2 -> v7.1.12
- Fix deprecated dist-url
    - https://github.com/electron/electron/blob/master/docs/breaking-changes.md#node-headers-url