### PR TITLE
Reduce app size by reducing large npm packages

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -4,6 +4,14 @@ directories:
   output: dist/production
   app: app/production
 
+files:
+  - "**/*"
+  - "!node_modules/sqlite3/{build,deps}"
+  - "!node_modules/aws-sdk/"
+  - "!node_modules/electron-is-dev/"
+  - "!node_modules/electron-log/"
+  - "!node_modules/@fortawesome/"
+
 publish:
   - provider: github
     owner: bdash-app

--- a/src/lib/Bdash.ts
+++ b/src/lib/Bdash.ts
@@ -6,6 +6,8 @@ import Database from "./Database";
 
 const Bdash = {
   async initialize() {
+    // @see https://github.com/bdash-app/bdash/pull/99#issuecomment-590011101
+    window.process["browser"] = true;
     if (!fs.existsSync(Config.bdashRoot)) {
       ensureDirSync(Config.bdashRoot);
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,12 +28,11 @@ module.exports = (env, argv) => {
   });
 
   const commonConfig = {
-    resolve: { extensions: [".ts", ".tsx"] },
+    resolve: { extensions: [".ts", ".tsx", ".js"] },
     node: {
       __dirname: false,
       __filename: false
-    },
-    externals: [nodeExternals({ whitelist: [/\.css$/] })]
+    }
   };
 
   const mainConfig = Object.assign(
@@ -53,7 +52,8 @@ module.exports = (env, argv) => {
             options: { transpileOnly: isDevelopment }
           }
         ]
-      }
+      },
+      externals: [nodeExternals({ whitelist: ["electron-is-dev", "electron-log"] })]
     },
     commonConfig
   );
@@ -90,6 +90,7 @@ module.exports = (env, argv) => {
           }
         ]
       },
+      externals: [nodeExternals({ whitelist: [/\.css$/, /^aws-sdk/, /^@fortawesome/] })],
       plugins: [extractTextPlugin, definePlugin, cleanPlugin, copyPlugin]
     },
     commonConfig


### PR DESCRIPTION
- Stop to bundle large size npm packages
    - `aws-sdk` (19MB)
    - `@fortawesome/font-awesome-free` (16MB)
- Delete node-sqlite3's build files

In my macOS environment:
Bdash.app size is 261MB => 216MB