### PR TITLE
Fix a bug data source could not be selected

### DIFF
--- a/src/renderer/pages/Query/Query.css
+++ b/src/renderer/pages/Query/Query.css
@@ -5,6 +5,7 @@
 
 .page-Query-splitter-layout {
   position: static;
+  z-index: 0;
 }
 
 .page-Query-list {
@@ -28,8 +29,4 @@
 .page-Query-main .QueryHeader {
   z-index: 1;
   height: var(--page-Query-headerHeight);
-}
-
-.page-Query-main .QueryEditor {
-  z-index: 0;
 }


### PR DESCRIPTION
The cause is that the structure of the DOM changed when splitter-layout was introduced.

FYI @mtgto 