### PR TITLE
Fix filter text field in tablelist is uncontrolled

### DIFF
--- a/src/renderer/components/TableList/TableList.tsx
+++ b/src/renderer/components/TableList/TableList.tsx
@@ -71,7 +71,11 @@ export default class TableList extends React.Component<Props> {
       <div className="TableList">
         <div className="TableList-filter">
           <i className="fas fa-search" />
-          <input type="search" value={dataSource.tableFilter} onChange={e => this.handleChangeTableFilter(e)} />
+          <input
+            type="search"
+            value={this.props.dataSource?.tableFilter ?? ""}
+            onChange={e => this.handleChangeTableFilter(e)}
+          />
         </div>
         <ul>{items}</ul>
       </div>


### PR DESCRIPTION
When typing in filter text field in table list, it causes warning in devtool console:
It happens when value of input tag is null or undefined.

<img width="665" alt="table_list_filter" src="https://user-images.githubusercontent.com/1213991/75109512-69827900-5667-11ea-97f7-4315f3b5a1e4.png">