### PR TITLE
Hotfix: query broken when switch another query since #104

### DIFF
--- a/src/renderer/components/QueryEditor/QueryEditor.tsx
+++ b/src/renderer/components/QueryEditor/QueryEditor.tsx
@@ -101,7 +101,7 @@ export default class QueryEditor extends React.Component<Props> {
         <Editor
           value={query.body || ""}
           rootRef={(node): void => (this.editorElement = node)}
-          onChange={this.props.onChangeQueryBody}
+          onChange={(body: string): void => this.props.onChangeQueryBody(body)}
           onChangeCursor={this.props.onChangeCursorPosition}
           onSubmit={this.props.onExecute}
           options={this.options}


### PR DESCRIPTION
When selected query is changed, old selected query body changes into new selected query.
This bug caused since #104