### PR TITLE
Fix Util/findQueryByLine splits at comma

### DIFF
--- a/src/lib/Util/findQueryByLine.ts
+++ b/src/lib/Util/findQueryByLine.ts
@@ -34,7 +34,7 @@ const splitQuery = (sql: string): Promise<QueryChunk[]> => {
     let query = "";
     const chunks: QueryChunk[] = [];
     runMode(sql, "text/x-sql", (token, style) => {
-      if (style === "punctuation") {
+      if (token === ";") {
         query += token;
         chunks.push({ query, startLine, endLine: line });
         query = "";

--- a/test/unit/lib/Util/findQueryByLine.test.ts
+++ b/test/unit/lib/Util/findQueryByLine.test.ts
@@ -5,7 +5,7 @@ import findQueryByLine from "../../../../src/lib/Util/findQueryByLine";
 suite("Util/findQueryByLine", () => {
   test("valid behavior", async () => {
     const sql = stripHeredoc(`
-      select a
+      select a1, a2
       from b;
       -- comment
 
@@ -17,7 +17,7 @@ suite("Util/findQueryByLine", () => {
       from c
     `);
 
-    const sql1 = "select a\nfrom b;";
+    const sql1 = "select a1, a2\nfrom b;";
     const sql2 = "-- comment\n\nselect 1\n;";
     const sql3 = "select 2\nfrom c";
 


### PR DESCRIPTION
Fix bug in #102

CodeMirrror treats both ";" and "," as `'punctuation`.
But #102 regards punctuation ";" only.

For example, this queries are valid.
```sql
select 1, 2;
select 3;
```

But wrong parser parses first line as "select 1,".