### PR TITLE
Use "Hiragino Sans" font for sans-serif fallback

### DIFF
--- a/src/renderer/styles/app.css
+++ b/src/renderer/styles/app.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: sans-serif;
+  font-family: "Hiragino Sans", sans-serif;
 }
 
 [hidden] {


### PR DESCRIPTION
Bdash v1.7.2 under macOS Catalina (10.15) uses serif fonts.
This bug is based on Chromium v78.
https://bugs.chromium.org/p/chromium/issues/detail?id=1000542

We choose two ways:

- Use `Hiragino Sans` as fallback font (This PR's way)
    - It causes changing the font in macOS Mojave (10.14)
- Upgrade Electron to v8.
    - Electron v8 uses Chromium v80 https://github.com/electron/electron/releases/tag/v8.0.0