### PR TITLE
Add draggable area in macOS

### DIFF
--- a/src/renderer/components/DataSourceList/DataSourceList.css
+++ b/src/renderer/components/DataSourceList/DataSourceList.css
@@ -10,6 +10,10 @@
   border-bottom: 1px solid #ccc;
 }
 
+.DataSourceList-new.darwin {
+  -webkit-app-region: drag;
+}
+
 .DataSourceList-new i {
   cursor: pointer;
 }

--- a/src/renderer/components/DataSourceList/DataSourceList.tsx
+++ b/src/renderer/components/DataSourceList/DataSourceList.tsx
@@ -90,7 +90,7 @@ export default class DataSourceList extends React.Component<Props> {
 
     return (
       <div className="DataSourceList">
-        <div className="DataSourceList-new">
+        <div className={classNames("DataSourceList-new", { darwin: process.platform === "darwin" })}>
           <i className="fas fa-plus" onClick={this.props.onClickNew} />
         </div>
         <ul className="DataSourceList-list">{items}</ul>

--- a/src/renderer/components/QueryList/QueryList.css
+++ b/src/renderer/components/QueryList/QueryList.css
@@ -4,6 +4,10 @@
   height: 100vh;
 }
 
+.QueryList-new.darwin {
+  -webkit-app-region: drag;
+}
+
 .QueryList-new {
   padding: 10px;
   font-size: 20px;

--- a/src/renderer/components/QueryList/QueryList.tsx
+++ b/src/renderer/components/QueryList/QueryList.tsx
@@ -68,7 +68,7 @@ export default class QueryList extends React.Component<Props> {
 
     return (
       <div className="QueryList">
-        <div className="QueryList-new">
+        <div className={classNames("QueryList-new", { darwin: process.platform === "darwin" })}>
           <i className="fas fa-plus" onClick={this.handleClickNew} />
         </div>
         <ul className="QueryList-list">{items}</ul>


### PR DESCRIPTION
In macOS, this PR adds draggable areas top item of Query list and top item of DataSource list.
cf. #115