### PR TITLE
Use mime type of CodeMirror

### DIFF
--- a/src/lib/DataSourceDefinition/Athena.ts
+++ b/src/lib/DataSourceDefinition/Athena.ts
@@ -1,11 +1,12 @@
 import AthenaClient from "../AthenaClient";
 import Base, { ConfigSchemasType } from "./Base";
 import Util from "../Util";
+import { DataSourceKeys } from "../../renderer/pages/DataSource/DataSourceStore";
 
 export default class Athena extends Base {
   client: AthenaClient;
 
-  static get key(): string {
+  static get key(): DataSourceKeys {
     return "athena";
   }
   static get label(): string {

--- a/src/lib/DataSourceDefinition/Base.ts
+++ b/src/lib/DataSourceDefinition/Base.ts
@@ -1,9 +1,9 @@
-import { TableType } from "../../renderer/pages/DataSource/DataSourceStore";
+import { DataSourceKeys, TableType } from "../../renderer/pages/DataSource/DataSourceStore";
 
 export default abstract class Base {
   config: any;
 
-  static get key(): string {
+  static get key(): DataSourceKeys {
     throw new Error("Not Implemented");
   }
   static get label(): string {

--- a/src/lib/DataSourceDefinition/BigQuery.ts
+++ b/src/lib/DataSourceDefinition/BigQuery.ts
@@ -1,11 +1,12 @@
 import bigquery from "@google-cloud/bigquery";
 import Base, { ConfigSchemasType } from "./Base";
 import { flatten } from "lodash";
+import { DataSourceKeys } from "../../renderer/pages/DataSource/DataSourceStore";
 
 export default class BigQuery extends Base {
   _cancel: any;
 
-  static get key(): string {
+  static get key(): DataSourceKeys {
     return "bigquery";
   }
   static get label(): string {

--- a/src/lib/DataSourceDefinition/Mysql.ts
+++ b/src/lib/DataSourceDefinition/Mysql.ts
@@ -3,11 +3,12 @@ import Base, { ConfigSchemasType } from "./Base";
 import Util from "../Util";
 import { zipObject } from "lodash";
 import { promises } from "fs";
+import { DataSourceKeys } from "../../renderer/pages/DataSource/DataSourceStore";
 
 export default class Mysql extends Base {
   currentConnection: any;
 
-  static get key(): string {
+  static get key(): DataSourceKeys {
     return "mysql";
   }
   static get label(): string {

--- a/src/lib/DataSourceDefinition/Postgres.ts
+++ b/src/lib/DataSourceDefinition/Postgres.ts
@@ -2,6 +2,7 @@ import pg from "pg";
 import Base, { ConfigSchemasType } from "./Base";
 import Util from "../Util";
 import { zipObject } from "lodash";
+import { DataSourceKeys } from "../../renderer/pages/DataSource/DataSourceStore";
 
 // Disable auto convert
 // https://github.com/brianc/node-pg-types/blob/ed2d0e36e33217b34530727a98d20b325389e73a/lib/textParsers.js#L147-L149
@@ -50,7 +51,7 @@ import { zipObject } from "lodash";
 export default class Postgres extends Base {
   currentClient: any;
 
-  static get key(): string {
+  static get key(): DataSourceKeys {
     return "postgres";
   }
   static get label(): string {

--- a/src/lib/DataSourceDefinition/Redshift.ts
+++ b/src/lib/DataSourceDefinition/Redshift.ts
@@ -1,9 +1,10 @@
 import Postgres from "./Postgres";
 import Util from "../Util";
 import { zipObject } from "lodash";
+import { DataSourceKeys } from "../../renderer/pages/DataSource/DataSourceStore";
 
 export default class Redshift extends Postgres {
-  static get key(): string {
+  static get key(): DataSourceKeys {
     return "redshift";
   }
 

--- a/src/lib/DataSourceDefinition/SQLite3.ts
+++ b/src/lib/DataSourceDefinition/SQLite3.ts
@@ -1,11 +1,12 @@
 import sqlite3 from "sqlite3";
 import Base, { ConfigSchemasType } from "./Base";
 import Util from "../Util";
+import { DataSourceKeys } from "../../renderer/pages/DataSource/DataSourceStore";
 
 export default class SQLite3 extends Base {
   db: sqlite3.Database | null;
 
-  static get key(): string {
+  static get key(): DataSourceKeys {
     return "sqlite3";
   }
   static get label(): string {

--- a/src/lib/DataSourceDefinition/TreasureData.ts
+++ b/src/lib/DataSourceDefinition/TreasureData.ts
@@ -1,6 +1,7 @@
 import TD from "td";
 import Base, { ConfigSchemasType } from "./Base";
 import Util from "../Util";
+import { DataSourceKeys } from "../../renderer/pages/DataSource/DataSourceStore";
 
 const WAIT_INTERVAL = 2000;
 
@@ -11,7 +12,7 @@ export default class TreasureData extends Base {
   _cancel: any;
   _client: any;
 
-  static get key(): string {
+  static get key(): DataSourceKeys {
     return "treasuredata";
   }
   static get label(): string {

--- a/src/lib/Database/DataSource.ts
+++ b/src/lib/Database/DataSource.ts
@@ -53,5 +53,28 @@ export default class DataSource {
 
 function convert(row: any): DataSourceType {
   const config = JSON.parse(row.config || "{}");
-  return Object.assign<DataSourceType, any>(row, { config });
+  return { ...row, ...{ config }, mimeType: mimeType(row) };
 }
+
+const mimeType = (dsType: DataSourceType): string => {
+  switch (dsType.type) {
+    case "postgres":
+    case "athena":
+    case "redshift":
+      return "text/x-pgsql";
+    case "mysql":
+      return "text/x-mysql";
+    case "sqlite3":
+      return "text/x-sqlite";
+    case "treasuredata":
+      if (dsType.config["queryType"] === "presco") {
+        return "text/x-sql";
+      } else {
+        return "text/x-hive";
+      }
+    case "bigquery":
+      return "text/x-gql";
+    default:
+      return "text/x-sql";
+  }
+};

--- a/src/lib/Util/findQueryByLine.ts
+++ b/src/lib/Util/findQueryByLine.ts
@@ -9,8 +9,8 @@ interface QueryChunk {
   endLine: number;
 }
 
-export default async function findQueryByLine(sql: string, line: number): Promise<QueryChunk> {
-  const chunks = await splitQuery(sql);
+export default async function findQueryByLine(sql: string, mimeType: string, line: number): Promise<QueryChunk> {
+  const chunks = await splitQuery(sql, mimeType);
   const chunk = chunks.find(chunk => chunk.endLine >= line) ?? last(chunks);
 
   if (!chunk) {
@@ -27,13 +27,13 @@ export default async function findQueryByLine(sql: string, line: number): Promis
   };
 }
 
-const splitQuery = (sql: string): Promise<QueryChunk[]> => {
+const splitQuery = (sql: string, mimeType: string): Promise<QueryChunk[]> => {
   return new Promise(resolve => {
     let startLine = 1;
     let line = 1;
     let query = "";
     const chunks: QueryChunk[] = [];
-    runMode(sql, "text/x-sql", (token, style) => {
+    runMode(sql, mimeType, (token, style) => {
       if (token === ";") {
         query += token;
         chunks.push({ query, startLine, endLine: line });

--- a/src/renderer/components/DataSourceForm/DataSourceForm.tsx
+++ b/src/renderer/components/DataSourceForm/DataSourceForm.tsx
@@ -4,7 +4,7 @@ import Button from "../Button";
 import DataSource, { DataSourceClasses } from "../../../lib/DataSource";
 import ProgressIcon from "../ProgressIcon";
 import { ConfigSchemaType } from "../../../lib/DataSourceDefinition/Base";
-import { DataSourceType } from "../../pages/DataSource/DataSourceStore";
+import { DataSourceKeys, DataSourceType } from "../../pages/DataSource/DataSourceStore";
 
 type Props = {
   readonly dataSource: DataSourceType | null;
@@ -13,7 +13,7 @@ type Props = {
 };
 
 type State = {
-  readonly selectedType: string | null;
+  readonly selectedType: DataSourceKeys | null;
   readonly connectionTestStatus: string | null;
   readonly connectionTestMessage: string | null;
 };
@@ -81,7 +81,7 @@ export default class DataSourceForm extends React.Component<Props, State> {
   }
 
   handleChangeType(e: React.ChangeEvent<HTMLSelectElement>): void {
-    this.setState({ selectedType: e.target.value });
+    this.setState({ selectedType: e.target.value as DataSourceKeys });
   }
 
   async handleConnectionTest(): Promise<void> {

--- a/src/renderer/components/QueryEditor/QueryEditor.tsx
+++ b/src/renderer/components/QueryEditor/QueryEditor.tsx
@@ -9,6 +9,7 @@ type Props = {
   readonly editor: { line: number | null };
   readonly setting: SettingType;
   readonly query: QueryType;
+  readonly mimeType: string;
   readonly onCancel: () => void;
   readonly onExecute: () => void;
   readonly onChangeEditorHeight: (height: number) => void;
@@ -21,7 +22,7 @@ export default class QueryEditor extends React.Component<Props> {
 
   get options(): EditorConfiguration {
     return {
-      mode: "text/x-sql",
+      mode: this.props.mimeType,
       keyMap: this.props.setting.keyBind,
       lineNumbers: true,
       matchBrackets: true,

--- a/src/renderer/pages/DataSource/DataSourceStore.ts
+++ b/src/renderer/pages/DataSource/DataSourceStore.ts
@@ -1,11 +1,14 @@
 import Store, { StateBuilder } from "../../flux/Store";
 import Setting, { SettingType } from "../../../lib/Setting";
 
+export type DataSourceKeys = "athena" | "bigquery" | "mysql" | "postgres" | "redshift" | "sqlite3" | "treasuredata";
+
 export type DataSourceType = {
   readonly id: number;
   readonly name: string;
-  readonly type: string;
+  readonly type: DataSourceKeys;
   readonly config: { [name: string]: any };
+  readonly mimeType: string;
 
   readonly tables: TableType[];
   readonly selectedTable: TableType;

--- a/src/renderer/pages/Query/Query.tsx
+++ b/src/renderer/pages/Query/Query.tsx
@@ -71,6 +71,7 @@ class Query extends React.Component<{}, QueryState> {
   renderMain(): React.ReactNode {
     const query = this.state.queries.find(query => query.id === this.state.selectedQueryId);
     if (!query) return <div className="page-Query-main" />;
+    const dataSource = this.state.dataSources.find(dataSource => dataSource.id === query.dataSourceId);
 
     return (
       <div className="page-Query-main">
@@ -93,6 +94,7 @@ class Query extends React.Component<{}, QueryState> {
         >
           <QueryEditor
             query={query}
+            mimeType={dataSource?.mimeType ?? "x-sql"}
             {...this.state}
             onChangeQueryBody={(body): void => {
               Action.updateQuery(query.id, { body });

--- a/src/renderer/pages/Query/Query.tsx
+++ b/src/renderer/pages/Query/Query.tsx
@@ -94,7 +94,7 @@ class Query extends React.Component<{}, QueryState> {
         >
           <QueryEditor
             query={query}
-            mimeType={dataSource?.mimeType ?? "x-sql"}
+            mimeType={dataSource?.mimeType ?? "text/x-sql"}
             {...this.state}
             onChangeQueryBody={(body): void => {
               Action.updateQuery(query.id, { body });

--- a/src/renderer/pages/Query/QueryAction.ts
+++ b/src/renderer/pages/Query/QueryAction.ts
@@ -64,7 +64,7 @@ const QueryAction = {
     query: QueryType;
     dataSource: DataSourceType;
   }): Promise<void> {
-    const { query: queryBody, startLine } = await Util.findQueryByLine(query.body, line);
+    const { query: queryBody, startLine } = await Util.findQueryByLine(query.body, dataSource.mimeType, line);
     const executor = DataSource.create(dataSource);
     const id = query.id;
     dispatch("updateQuery", { id, params: { status: "working", executor } });

--- a/test/unit/lib/Database/DataSource.test.ts
+++ b/test/unit/lib/Database/DataSource.test.ts
@@ -16,8 +16,8 @@ suite("Database/DataSource", () => {
     `);
     const rows = await DataSource.getAll();
     assert.deepStrictEqual(rows, [
-      { id: 2, name: "name 2", type: "mysql", config: { foo: "bar" } },
-      { id: 1, name: "name 1", type: "mysql", config: { foo: "bar" } }
+      { id: 2, name: "name 2", type: "mysql", mimeType: "text/x-mysql", config: { foo: "bar" } },
+      { id: 1, name: "name 1", type: "mysql", mimeType: "text/x-mysql", config: { foo: "bar" } }
     ]);
   });
 
@@ -33,6 +33,7 @@ suite("Database/DataSource", () => {
       id: 1,
       name: "name 1",
       type: "mysql",
+      mimeType: "text/x-mysql",
       config: { foo: "bar" },
       updatedAt: "2017-02-01 00:00:00",
       createdAt: "2017-01-01 00:00:00"

--- a/test/unit/lib/Util/findQueryByLine.test.ts
+++ b/test/unit/lib/Util/findQueryByLine.test.ts
@@ -21,47 +21,47 @@ suite("Util/findQueryByLine", () => {
     const sql2 = "-- comment\n\nselect 1\n;";
     const sql3 = "select 2\nfrom c";
 
-    assert.deepStrictEqual(await findQueryByLine(sql, 1), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 1), {
       query: sql1,
       startLine: 1,
       endLine: 2
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 2), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 2), {
       query: sql1,
       startLine: 1,
       endLine: 2
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 3), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 3), {
       query: sql2,
       startLine: 3,
       endLine: 6
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 4), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 4), {
       query: sql2,
       startLine: 3,
       endLine: 6
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 5), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 5), {
       query: sql2,
       startLine: 3,
       endLine: 6
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 6), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 6), {
       query: sql2,
       startLine: 3,
       endLine: 6
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 7), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 7), {
       query: sql3,
       startLine: 9,
       endLine: 10
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 8), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 8), {
       query: sql3,
       startLine: 9,
       endLine: 10
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 9), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 9), {
       query: sql3,
       startLine: 9,
       endLine: 10
@@ -73,22 +73,22 @@ suite("Util/findQueryByLine", () => {
     const sql1 = "select 1;";
     const sql2 = "select 2;";
 
-    assert.deepStrictEqual(await findQueryByLine(sql, 1), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 1), {
       query: sql1,
       startLine: 2,
       endLine: 2
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 2), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 2), {
       query: sql1,
       startLine: 2,
       endLine: 2
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 3), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 3), {
       query: sql2,
       startLine: 3,
       endLine: 3
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 4), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 4), {
       query: sql2,
       startLine: 3,
       endLine: 3
@@ -97,7 +97,7 @@ suite("Util/findQueryByLine", () => {
 
   test("only one line", async () => {
     const sql = "select 1;";
-    assert.deepStrictEqual(await findQueryByLine(sql, 1), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 1), {
       query: "select 1;",
       startLine: 1,
       endLine: 1
@@ -106,7 +106,7 @@ suite("Util/findQueryByLine", () => {
 
   test("only one line and first line is blank", async () => {
     const sql = "\nselect 1;";
-    assert.deepStrictEqual(await findQueryByLine(sql, 1), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 1), {
       query: "select 1;",
       startLine: 2,
       endLine: 2
@@ -119,17 +119,17 @@ suite("Util/findQueryByLine", () => {
       select 4 ; select a
       from b
     `);
-    assert.deepStrictEqual(await findQueryByLine(sql, 1), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 1), {
       query: "select 1;",
       startLine: 1,
       endLine: 1
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 2), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 2), {
       query: "-- comment select 2; select 3\nselect 4 ;",
       startLine: 1,
       endLine: 2
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 3), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 3), {
       query: "select a\nfrom b",
       startLine: 2,
       endLine: 3
@@ -142,12 +142,12 @@ suite("Util/findQueryByLine", () => {
       select 4; */ select a
       from b
     `);
-    assert.deepStrictEqual(await findQueryByLine(sql, 1), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 1), {
       query: "select 1;",
       startLine: 1,
       endLine: 1
     });
-    assert.deepStrictEqual(await findQueryByLine(sql, 2), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 2), {
       query: "/* select 2; select 3;\nselect 4; */ select a\nfrom b",
       startLine: 1,
       endLine: 3
@@ -161,7 +161,7 @@ suite("Util/findQueryByLine", () => {
       )
       select 2 from baz;
     `);
-    assert.deepStrictEqual(await findQueryByLine(sql, 2), {
+    assert.deepStrictEqual(await findQueryByLine(sql, "text/x-sql", 2), {
       query: "with foo as (\n  select 1 from bar\n)\nselect 2 from baz;",
       startLine: 1,
       endLine: 4


### PR DESCRIPTION
To colorize, use specific MIME type of CodeMirror.

Example: `serial8` is keyword of PostgreSQL, but not keyword of SQLite3, MySQL.
![image](https://user-images.githubusercontent.com/1213991/81373950-ec7c8100-9138-11ea-8fab-dc1caff8293e.png)
