### PR TITLE
Add line wrapping setting

### DIFF
--- a/src/lib/Setting.ts
+++ b/src/lib/Setting.ts
@@ -4,6 +4,7 @@ import _ from "lodash";
 
 export type SettingType = {
   readonly keyBind: "default" | "vim";
+  readonly lineWrap: boolean;
   readonly github: GithubSettingType;
   readonly defaultDataSourceId?: number;
 };
@@ -20,6 +21,7 @@ export default class Setting {
   static getDefault(): SettingType {
     return {
       keyBind: "default",
+      lineWrap: false,
       github: {
         token: null,
         url: null

--- a/src/renderer/components/QueryEditor/QueryEditor.tsx
+++ b/src/renderer/components/QueryEditor/QueryEditor.tsx
@@ -25,6 +25,7 @@ export default class QueryEditor extends React.Component<Props> {
       mode: this.props.mimeType,
       keyMap: this.props.setting.keyBind,
       lineNumbers: true,
+      lineWrapping: this.props.setting.lineWrap,
       matchBrackets: true,
       indentUnit: 4,
       smartIndent: false,

--- a/src/renderer/pages/Setting/Setting.tsx
+++ b/src/renderer/pages/Setting/Setting.tsx
@@ -38,6 +38,14 @@ class Setting extends React.Component<{}, SettingState> {
               styles={selectStyles}
             />
           </div>
+          <div className="page-Setting-section2 page-Setting-keyBind">
+            <h2>Line wrap</h2>
+            <input
+              type="checkbox"
+              onChange={(e): void => Action.update({ lineWrap: e.target.checked })}
+              checked={setting.lineWrap}
+            />
+          </div>
         </div>
 
         <div className="page-Setting-section1">

--- a/src/renderer/pages/Setting/Setting.tsx
+++ b/src/renderer/pages/Setting/Setting.tsx
@@ -38,7 +38,7 @@ class Setting extends React.Component<{}, SettingState> {
               styles={selectStyles}
             />
           </div>
-          <div className="page-Setting-section2 page-Setting-keyBind">
+          <div className="page-Setting-section2 page-Setting-lineWrap">
             <h2>Line wrap</h2>
             <input
               type="checkbox"


### PR DESCRIPTION
closes #127 

Add checkbox config to enable/disable line wrapping of query editor. Default value is false.

Screenshots:

![image](https://user-images.githubusercontent.com/1213991/81409277-cb885000-9179-11ea-8308-df3f66a658aa.png)
![image](https://user-images.githubusercontent.com/1213991/81409290-d17e3100-9179-11ea-97e2-83d82b486bd4.png)
