### PR TITLE
Use pg_attrdef.adbin to get default value of columns

### DIFF
--- a/src/lib/DataSourceDefinition/Postgres.ts
+++ b/src/lib/DataSourceDefinition/Postgres.ts
@@ -117,7 +117,7 @@ export default class Postgres extends Base {
           pg_attribute.attname as name,
           pg_attribute.atttypid::regtype as type,
           case pg_attribute.attnotnull when true then 'NO' else 'YES' end as null,
-          pg_attrdef.adsrc as default_value,
+          pg_get_expr(pg_attrdef.adbin, pg_attrdef.adrelid) as default_value,
           pg_description.description as description
       from
           pg_attribute


### PR DESCRIPTION
pg_attrdef.adsrc has been removed in PostgreSQL 12.
https://www.postgresql.org/docs/12/release-12.html
pg_attdef.adbin is also available in 9.5, which is the oldest supported
version currently.
https://www.postgresql.org/docs/9.5/catalog-pg-attrdef.html

Resolves #131 