### PR TITLE
show dialog when webView is crashed

### DIFF
--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,5 +1,6 @@
-import electron, { BrowserWindow } from "electron";
+import electron, { BrowserWindow, dialog } from "electron";
 import path from "path";
+import logger from "./logger";
 
 const windows: BrowserWindow[] = [];
 
@@ -19,6 +20,10 @@ export async function createWindow(): Promise<void> {
   win.once("closed", () => {
     const idx = windows.findIndex(w => w === win);
     windows.splice(idx, 1);
+  });
+  win.webContents.on("crashed", e => {
+    logger.error("renderer process crashed", e);
+    dialog.showErrorBox("Bdash is crashed", "Unrecoverable error");
   });
 
   windows.push(win);


### PR DESCRIPTION
This changes shows dialog when renderer is crashed (caused by OOM, etc.)
https://www.electronjs.org/docs/api/web-contents#event-crashed

We might say "You need to restart Bdash" by dialog.

(Screenshot says app window is dyed white)
<img width="1280" alt="crash" src="https://user-images.githubusercontent.com/1213991/86369657-b8958600-bcb9-11ea-8c8d-2194dbd5c12e.png">
