### PR TITLE
fix empty response of Sqlite3

### DIFF
--- a/src/lib/DataSourceDefinition/SQLite3.ts
+++ b/src/lib/DataSourceDefinition/SQLite3.ts
@@ -45,7 +45,7 @@ export default class SQLite3 extends Base {
     return this._execute("select 1");
   }
 
-  _execute(query: string): Promise<any> {
+  _execute(query: string): Promise<{ rows: (string | null)[][]; fields: string[] }> {
     this.db = new sqlite3.Database(this.config.path);
     return new Promise((resolve, reject) => {
       this.db?.all(query, (err, results) => {
@@ -55,10 +55,10 @@ export default class SQLite3 extends Base {
           return reject(err);
         }
         if (results.length === 0) {
-          return resolve([]);
+          return resolve({ rows: [], fields: [] });
         }
         const fields = Object.keys(results[0]);
-        const rows = results.map(r => Object.values(r));
+        const rows = results.map<(string | null)[]>(r => Object.values(r));
         resolve({ fields, rows });
       });
     });

--- a/test/fixtures/sqlite3/initialize.ts
+++ b/test/fixtures/sqlite3/initialize.ts
@@ -1,0 +1,20 @@
+import { Database } from "sqlite3";
+
+export default async function initialize(path: string): Promise<any> {
+  const db: Database = new Database(path);
+  const execute = async (query: string): Promise<any> =>
+    new Promise((resolve, reject) => {
+      db.all(query, (err, results) => {
+        if (err) {
+          reject(err);
+          return;
+        } else {
+          resolve(results);
+        }
+      });
+    });
+
+  await execute("drop table if exists test;");
+  await execute("create table test (id int, text varchar(255));");
+  await execute("insert into test (id, text) values (1, 'foo'), (2, 'bar'), (3, 'baz');");
+}

--- a/test/unit/lib/DataSourceDefinition/Sqlite3.test.ts
+++ b/test/unit/lib/DataSourceDefinition/Sqlite3.test.ts
@@ -1,0 +1,61 @@
+import assert from "assert";
+import initialize from "../../../fixtures/sqlite3/initialize";
+import SQLite3 from "../../../../src/lib/DataSourceDefinition/SQLite3";
+import os from "os";
+import fs from "fs";
+import path from "path";
+import { promisify } from "util";
+
+suite("DataSourceDefinition/SQLite3 @remote", () => {
+  const dbPath = path.join(os.tmpdir(), `bdash.${Math.floor(Math.random() * 100000)}.db`);
+  const connection = new SQLite3({ path: dbPath });
+
+  suiteSetup(async () => {
+    await initialize(dbPath);
+  });
+
+  suiteTeardown(async () => {
+    await promisify(fs.unlink)(dbPath);
+  });
+
+  test("select (empty)", async () => {
+    const result = await connection.execute("select id, text from test where 1 = 2");
+    assert.deepEqual(result, { fields: [], rows: [] });
+  });
+
+  test("select (non-empty)", async () => {
+    const result = await connection.execute("select id, text from test order by id");
+    assert.deepStrictEqual(result, {
+      fields: ["id", "text"],
+      rows: [
+        [1, "foo"],
+        [2, "bar"],
+        [3, "baz"]
+      ]
+    });
+  });
+
+  test("insert", async () => {
+    const result = await connection.execute("insert into test values (4, 'hoge')");
+    assert.deepStrictEqual(result, {
+      fields: [],
+      rows: []
+    });
+  });
+
+  test("update", async () => {
+    const result = await connection.execute("update test set text = 'hoge'");
+    assert.deepStrictEqual(result, {
+      fields: [],
+      rows: []
+    });
+  });
+
+  test("delete", async () => {
+    const result = await connection.execute("delete from test where id = 1");
+    assert.deepStrictEqual(result, {
+      fields: [],
+      rows: []
+    });
+  });
+});


### PR DESCRIPTION
TableSummary component says `Cannot read property 'map' of undefined` when sqlite3 database has no table.

![image](https://user-images.githubusercontent.com/1213991/86374376-73745280-bcbf-11ea-98b4-97ae481ad39a.png)

To fix it, set correct response for empty result for sqlite3.
In addition, add unit test for sqlite3.