### PR TITLE
Set limit the maximum number of lines of gist

### DIFF
--- a/src/lib/QuerySharing.ts
+++ b/src/lib/QuerySharing.ts
@@ -22,7 +22,10 @@ export default {
     setting: GithubSettingType;
     dataSource: DataSourceType;
   }): Promise<void> {
-    const [tsv, svg] = await Promise.all([getTableDataAsTsv(query), getChartAsSvg(query, chart)]);
+    const [tsv, svg] = await Promise.all([
+      getTableDataAsTsv(query, setting.maximumNumberOfRowsOfGist),
+      getChartAsSvg(query, chart)
+    ]);
 
     const description = query.title;
     const infoMd = Util.stripHeredoc(`
@@ -54,13 +57,13 @@ export default {
     await electron.shell.openExternal(result.html_url);
   },
 
-  copyAsMarkdown(query: QueryType): void {
-    const markdown = markdownTable(getTableData(query));
+  copyAsMarkdown(query: QueryType, maximumNumberOfRowsOfGist: number): void {
+    const markdown = markdownTable(getTableData(query, maximumNumberOfRowsOfGist));
     electron.clipboard.writeText(markdown);
   },
 
-  async copyAsTsv(query: QueryType): Promise<void> {
-    const tsv = await getTableDataAsTsv(query);
+  async copyAsTsv(query: QueryType, maximumNumberOfRowsOfGist: number): Promise<void> {
+    const tsv = await getTableDataAsTsv(query, maximumNumberOfRowsOfGist);
     return electron.clipboard.writeText(tsv);
   },
 
@@ -71,14 +74,14 @@ export default {
 };
 
 // private functions
-function getTableData(query: QueryType): any[] {
-  const rows = query.rows.slice(0, 10000).map(row => Object.values(row));
+function getTableData(query: QueryType, maximumNumberOfRowsOfGist: number): any[] {
+  const rows = query.rows.slice(0, maximumNumberOfRowsOfGist).map(row => Object.values(row));
   return [query.fields].concat(rows);
 }
 
-function getTableDataAsTsv(query: QueryType): Promise<string> {
+function getTableDataAsTsv(query: QueryType, maximumNumberOfRowsOfGist: number): Promise<string> {
   return new Promise((resolve, reject) => {
-    csvStringify(getTableData(query), { delimiter: "\t" }, (err, tsv) => {
+    csvStringify(getTableData(query, maximumNumberOfRowsOfGist), { delimiter: "\t" }, (err, tsv) => {
       if (err) {
         reject(err);
       } else {

--- a/src/lib/QuerySharing.ts
+++ b/src/lib/QuerySharing.ts
@@ -72,7 +72,7 @@ export default {
 
 // private functions
 function getTableData(query: QueryType): any[] {
-  const rows = query.rows.map(row => Object.values(row));
+  const rows = query.rows.slice(0, 10000).map(row => Object.values(row));
   return [query.fields].concat(rows);
 }
 

--- a/src/lib/QuerySharing.ts
+++ b/src/lib/QuerySharing.ts
@@ -57,12 +57,12 @@ export default {
     await electron.shell.openExternal(result.html_url);
   },
 
-  copyAsMarkdown(query: QueryType, maximumNumberOfRowsOfGist: number): void {
+  copyAsMarkdown(query: QueryType, maximumNumberOfRowsOfGist?: number): void {
     const markdown = markdownTable(getTableData(query, maximumNumberOfRowsOfGist));
     electron.clipboard.writeText(markdown);
   },
 
-  async copyAsTsv(query: QueryType, maximumNumberOfRowsOfGist: number): Promise<void> {
+  async copyAsTsv(query: QueryType, maximumNumberOfRowsOfGist?: number): Promise<void> {
     const tsv = await getTableDataAsTsv(query, maximumNumberOfRowsOfGist);
     return electron.clipboard.writeText(tsv);
   },
@@ -74,12 +74,12 @@ export default {
 };
 
 // private functions
-function getTableData(query: QueryType, maximumNumberOfRowsOfGist: number): any[] {
-  const rows = query.rows.slice(0, maximumNumberOfRowsOfGist).map(row => Object.values(row));
-  return [query.fields].concat(rows);
+function getTableData(query: QueryType, maximumNumberOfRowsOfGist?: number): any[] {
+  const rows = maximumNumberOfRowsOfGist ? query.rows.slice(0, maximumNumberOfRowsOfGist) : query.rows;
+  return [query.fields].concat(rows.map(row => Object.values(row)));
 }
 
-function getTableDataAsTsv(query: QueryType, maximumNumberOfRowsOfGist: number): Promise<string> {
+function getTableDataAsTsv(query: QueryType, maximumNumberOfRowsOfGist?: number): Promise<string> {
   return new Promise((resolve, reject) => {
     csvStringify(getTableData(query, maximumNumberOfRowsOfGist), { delimiter: "\t" }, (err, tsv) => {
       if (err) {

--- a/src/lib/Setting.ts
+++ b/src/lib/Setting.ts
@@ -12,6 +12,7 @@ export type SettingType = {
 export type GithubSettingType = {
   readonly token: string | null;
   readonly url: string | null;
+  readonly maximumNumberOfRowsOfGist: number;
 };
 
 // type for partial updating parameter.
@@ -24,7 +25,8 @@ export default class Setting {
       lineWrap: false,
       github: {
         token: null,
-        url: null
+        url: null,
+        maximumNumberOfRowsOfGist: 10000
       },
       defaultDataSourceId: undefined
     };
@@ -40,7 +42,11 @@ export default class Setting {
       fs.writeFileSync(filePath, "", { mode: 0o600 });
     }
 
-    this.setting = yaml.safeLoad(fs.readFileSync(filePath).toString()) || {};
+    this.setting =
+      {
+        ...Setting.getDefault(),
+        ...yaml.safeLoad(fs.readFileSync(filePath).toString())
+      } || {};
   }
 
   load(): SettingType {

--- a/src/renderer/pages/Setting/Setting.css
+++ b/src/renderer/pages/Setting/Setting.css
@@ -29,7 +29,8 @@
   width: 150px;
 }
 
-.page-Setting input[type="text"] {
+.page-Setting input[type="text"],
+.page-Setting input[type="number"] {
   width: 300px;
   padding: 5px;
   outline: none;

--- a/src/renderer/pages/Setting/Setting.tsx
+++ b/src/renderer/pages/Setting/Setting.tsx
@@ -67,7 +67,7 @@ class Setting extends React.Component<unknown, SettingState> {
               placeholder="https://yourdomain/api/v3"
             />
           </div>
-          <div className="page-Setting-validateToken">
+          <div className="page-Setting-validateToken page-Setting-section2">
             <Button
               onClick={(): void => {
                 Action.validateGithubToken(github);
@@ -76,6 +76,16 @@ class Setting extends React.Component<unknown, SettingState> {
               Validate Token
             </Button>
             {this.renderGithubValidateTokenResult()}
+          </div>
+          <div className="page-Setting-section2">
+            <h2>Maximum number of rows</h2>
+            <input
+              type="number"
+              max={1000000}
+              min={0}
+              value={github.maximumNumberOfRowsOfGist}
+              onChange={(e): void => Action.update({ github: { maximumNumberOfRowsOfGist: Number(e.target.value) } })}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
To protect from out of memory error, add limit the maximum number of lines for sharing the query to gist.
Default maximum number of rows is 10,000.

Screenshot

![image](https://user-images.githubusercontent.com/1213991/86778576-8018f200-c095-11ea-8ced-04a329791aa1.png)
