### PR TITLE
Add feature to save editor history for each queries

### DIFF
--- a/src/lib/Database/Query.ts
+++ b/src/lib/Database/Query.ts
@@ -12,11 +12,18 @@ export type QueryType = {
   readonly rows?: any;
   readonly status?: "success" | "failure" | "working";
   readonly chart?: ChartType;
-  readonly runtime?: number;
-  readonly errorMessage?: string;
+  readonly runtime?: number | null;
+  readonly errorMessage?: string | null;
   readonly selectedTab?: "table" | "chart";
   readonly executor?: Base | null;
   readonly runAt?: moment.Moment;
+  readonly history?: Record<string, unknown> | null; // Edit history of CodeMirror.Doc. https://codemirror.net/doc/manual.html#getHistory
+};
+
+export type DatabaseQueryType = Omit<QueryType, "fields" | "rows" | "history"> & {
+  fields: string | null;
+  rows: string | null;
+  history: string | null;
 };
 
 export default class Query {
@@ -47,6 +54,10 @@ export default class Query {
       query.rows = query.rows.map(r => Object.values(r));
     }
 
+    if (query.history) {
+      query.history = JSON.parse(query.history);
+    }
+
     return query;
   }
 
@@ -61,7 +72,7 @@ export default class Query {
     return { id, dataSourceId, title, body };
   }
 
-  static update(id: number, params: any): Promise<void> {
+  static update(id: number, params: Partial<DatabaseQueryType>): Promise<void> {
     const fields: string[] = [];
     const values: string[] = [];
 

--- a/src/lib/Database/Query.ts
+++ b/src/lib/Database/Query.ts
@@ -17,13 +17,13 @@ export type QueryType = {
   readonly selectedTab?: "table" | "chart";
   readonly executor?: Base | null;
   readonly runAt?: moment.Moment;
-  readonly history?: Record<string, unknown> | null; // Edit history of CodeMirror.Doc. https://codemirror.net/doc/manual.html#getHistory
+  readonly codeMirrorHistory?: Record<string, unknown> | null; // Edit history of CodeMirror.Doc. https://codemirror.net/doc/manual.html#getHistory
 };
 
-export type DatabaseQueryType = Omit<QueryType, "fields" | "rows" | "history"> & {
+export type DatabaseQueryType = Omit<QueryType, "fields" | "rows" | "codeMirrorHistory"> & {
   fields: string | null;
   rows: string | null;
-  history: string | null;
+  codeMirrorHistory: string | null;
 };
 
 export default class Query {
@@ -54,8 +54,8 @@ export default class Query {
       query.rows = query.rows.map(r => Object.values(r));
     }
 
-    if (query.history) {
-      query.history = JSON.parse(query.history);
+    if (query.codeMirrorHistory) {
+      query.codeMirrorHistory = JSON.parse(query.codeMirrorHistory);
     }
 
     return query;

--- a/src/lib/Database/schema.ts
+++ b/src/lib/Database/schema.ts
@@ -44,5 +44,9 @@ export const migrations: Migration[] = [
     );
     create index if not exists idx_query_id_on_charts on charts(queryId);
     `
+  },
+  {
+    version: 2,
+    query: `alter table queries add column history json`
   }
 ];

--- a/src/lib/Database/schema.ts
+++ b/src/lib/Database/schema.ts
@@ -47,6 +47,6 @@ export const migrations: Migration[] = [
   },
   {
     version: 2,
-    query: `alter table queries add column history json`
+    query: `alter table queries add column codeMirrorHistory json`
   }
 ];

--- a/src/renderer/components/Editor/Editor.tsx
+++ b/src/renderer/components/Editor/Editor.tsx
@@ -14,10 +14,10 @@ import { isEqual } from "lodash";
 type Props = {
   readonly options: CodeMirror.EditorConfiguration;
   readonly value: string;
-  readonly history?: Record<string, unknown>;
+  readonly codeMirrorHistory?: Record<string, unknown>;
   readonly rootRef: React.Ref<any>;
   readonly onSubmit: () => void;
-  readonly onChange: (change: string, history: Record<string, unknown>) => void;
+  readonly onChange: (change: string, codeMirrorHistory: Record<string, unknown>) => void;
   readonly onChangeCursor: (lineNumber: number) => void;
 };
 
@@ -61,8 +61,8 @@ export default class Editor extends React.Component<Props> {
     this.currentValue = this.props.value;
     this.currentOptions = this.props.options;
     this.codeMirror.setValue(this.currentValue);
-    if (this.props.history) {
-      this.codeMirror.setHistory(this.props.history);
+    if (this.props.codeMirrorHistory) {
+      this.codeMirror.setHistory(this.props.codeMirrorHistory);
     } else {
       this.codeMirror.clearHistory();
     }
@@ -92,8 +92,8 @@ export default class Editor extends React.Component<Props> {
     if (this.currentValue !== nextProps.value) {
       this.ignoreTriggerChangeEvent = true;
       this.codeMirror.setValue(nextProps.value);
-      if (nextProps.history) {
-        this.codeMirror.setHistory(nextProps.history);
+      if (nextProps.codeMirrorHistory) {
+        this.codeMirror.setHistory(nextProps.codeMirrorHistory);
       } else {
         this.codeMirror.clearHistory();
       }

--- a/src/renderer/components/Editor/Editor.tsx
+++ b/src/renderer/components/Editor/Editor.tsx
@@ -14,9 +14,10 @@ import { isEqual } from "lodash";
 type Props = {
   readonly options: CodeMirror.EditorConfiguration;
   readonly value: string;
+  readonly history?: Record<string, unknown>;
   readonly rootRef: React.Ref<any>;
   readonly onSubmit: () => void;
-  readonly onChange: (change: string) => void;
+  readonly onChange: (change: string, history: Record<string, unknown>) => void;
   readonly onChangeCursor: (lineNumber: number) => void;
 };
 
@@ -60,6 +61,11 @@ export default class Editor extends React.Component<Props> {
     this.currentValue = this.props.value;
     this.currentOptions = this.props.options;
     this.codeMirror.setValue(this.currentValue);
+    if (this.props.history) {
+      this.codeMirror.setHistory(this.props.history);
+    } else {
+      this.codeMirror.clearHistory();
+    }
     CodeMirror.Vim.defineAction("delLineLeft", cm => cm.execCommand("delLineLeft"));
     CodeMirror.Vim._mapCommand({
       keys: "<C-u>",
@@ -86,6 +92,11 @@ export default class Editor extends React.Component<Props> {
     if (this.currentValue !== nextProps.value) {
       this.ignoreTriggerChangeEvent = true;
       this.codeMirror.setValue(nextProps.value);
+      if (nextProps.history) {
+        this.codeMirror.setHistory(nextProps.history);
+      } else {
+        this.codeMirror.clearHistory();
+      }
       this.ignoreTriggerChangeEvent = false;
     }
 
@@ -97,17 +108,17 @@ export default class Editor extends React.Component<Props> {
     }
   }
 
-  handleValueChange(doc: CodeMirror.Doc): void {
-    const newValue = doc.getValue();
+  handleValueChange(editor: CodeMirror.Editor): void {
+    const newValue = editor.getValue();
     this.currentValue = newValue;
 
     if (this.ignoreTriggerChangeEvent === false) {
-      this.props.onChange && this.props.onChange(newValue);
+      this.props.onChange && this.props.onChange(newValue, editor.getHistory());
     }
   }
 
-  handleCursorChange(doc: CodeMirror.Doc): void {
-    const cursor = doc.getCursor();
+  handleCursorChange(editor: CodeMirror.Editor): void {
+    const cursor = editor.getCursor();
     const line = (cursor.line || 0) + 1;
     this.props.onChangeCursor(line);
   }

--- a/src/renderer/components/QueryEditor/QueryEditor.tsx
+++ b/src/renderer/components/QueryEditor/QueryEditor.tsx
@@ -13,7 +13,7 @@ type Props = {
   readonly onCancel: () => void;
   readonly onExecute: () => void;
   readonly onChangeEditorHeight: (height: number) => void;
-  readonly onChangeQueryBody: (body: string, history: Record<string, unknown>) => void;
+  readonly onChangeQueryBody: (body: string, codeMirrorHistory: Record<string, unknown>) => void;
   readonly onChangeCursorPosition: (lineNumber: number) => void;
 };
 
@@ -108,7 +108,7 @@ export default class QueryEditor extends React.Component<Props> {
           onChangeCursor={this.props.onChangeCursorPosition}
           onSubmit={this.props.onExecute}
           options={this.options}
-          history={this.props.query.history ?? undefined}
+          codeMirrorHistory={this.props.query.codeMirrorHistory ?? undefined}
         />
         <div className="QueryEditor-navbar">
           {this.renderButton()}

--- a/src/renderer/components/QueryEditor/QueryEditor.tsx
+++ b/src/renderer/components/QueryEditor/QueryEditor.tsx
@@ -13,7 +13,7 @@ type Props = {
   readonly onCancel: () => void;
   readonly onExecute: () => void;
   readonly onChangeEditorHeight: (height: number) => void;
-  readonly onChangeQueryBody: (body: string) => void;
+  readonly onChangeQueryBody: (body: string, history: Record<string, unknown>) => void;
   readonly onChangeCursorPosition: (lineNumber: number) => void;
 };
 
@@ -108,6 +108,7 @@ export default class QueryEditor extends React.Component<Props> {
           onChangeCursor={this.props.onChangeCursorPosition}
           onSubmit={this.props.onExecute}
           options={this.options}
+          history={this.props.query.history ?? undefined}
         />
         <div className="QueryEditor-navbar">
           {this.renderButton()}

--- a/src/renderer/pages/Query/Query.tsx
+++ b/src/renderer/pages/Query/Query.tsx
@@ -96,8 +96,8 @@ class Query extends React.Component<unknown, QueryState> {
             query={query}
             mimeType={dataSource?.mimeType ?? "text/x-sql"}
             {...this.state}
-            onChangeQueryBody={(body, history): void => {
-              Action.updateQuery(query.id, { body, history });
+            onChangeQueryBody={(body, codeMirrorHistory): void => {
+              Action.updateQuery(query.id, { body, codeMirrorHistory: codeMirrorHistory });
             }}
             onChangeCursorPosition={(line): void => Action.updateEditor({ line })}
             onChangeEditorHeight={(height): void => Action.updateEditor({ height })}

--- a/src/renderer/pages/Query/Query.tsx
+++ b/src/renderer/pages/Query/Query.tsx
@@ -96,8 +96,8 @@ class Query extends React.Component<unknown, QueryState> {
             query={query}
             mimeType={dataSource?.mimeType ?? "text/x-sql"}
             {...this.state}
-            onChangeQueryBody={(body): void => {
-              Action.updateQuery(query.id, { body });
+            onChangeQueryBody={(body, history): void => {
+              Action.updateQuery(query.id, { body, history });
             }}
             onChangeCursorPosition={(line): void => Action.updateEditor({ line })}
             onChangeEditorHeight={(height): void => Action.updateEditor({ height })}

--- a/src/renderer/pages/Query/QueryAction.ts
+++ b/src/renderer/pages/Query/QueryAction.ts
@@ -4,7 +4,7 @@ import { setting } from "../../../lib/Setting";
 import Database from "../../../lib/Database";
 import Util from "../../../lib/Util";
 import DataSource from "../../../lib/DataSource";
-import { QueryType } from "../../../lib/Database/Query";
+import { QueryType, DatabaseQueryType } from "../../../lib/Database/Query";
 import { DataSourceType } from "../DataSource/DataSourceStore";
 
 const DEFAULT_QUERY_TITLE = "New Query";
@@ -40,9 +40,12 @@ const QueryAction = {
     dispatch("addNewQuery", { query });
   },
 
-  updateQuery(id: number, params: any): Promise<void> {
+  updateQuery(id: number, params: Partial<QueryType>): Promise<void> {
     dispatch("updateQuery", { id, params });
-    return Database.Query.update(id, params);
+    return Database.Query.update(id, {
+      ...params,
+      history: params.history ? JSON.stringify(params.history) : null
+    });
   },
 
   async duplicateQuery(query: QueryType): Promise<void> {
@@ -74,7 +77,7 @@ const QueryAction = {
     try {
       result = await executor.execute(queryBody, { startLine });
     } catch (err) {
-      const params = {
+      const params: Partial<DatabaseQueryType> = {
         status: "failure",
         fields: null,
         rows: null,
@@ -89,7 +92,7 @@ const QueryAction = {
       return;
     }
 
-    const params = {
+    const params: Partial<DatabaseQueryType> = {
       status: "success",
       fields: result.fields,
       rows: result.rows,
@@ -106,7 +109,7 @@ const QueryAction = {
       Object.assign(params, {
         fields: JSON.stringify(params.fields),
         rows: JSON.stringify(params.rows),
-        runAt: params.runAt.utc().format("YYYY-MM-DD HH:mm:ss")
+        runAt: params.runAt?.utc().format("YYYY-MM-DD HH:mm:ss")
       })
     );
   },

--- a/src/renderer/pages/Query/QueryAction.ts
+++ b/src/renderer/pages/Query/QueryAction.ts
@@ -44,7 +44,7 @@ const QueryAction = {
     dispatch("updateQuery", { id, params });
     return Database.Query.update(id, {
       ...params,
-      history: params.history ? JSON.stringify(params.history) : null
+      codeMirrorHistory: params.codeMirrorHistory ? JSON.stringify(params.codeMirrorHistory) : null
     });
   },
 

--- a/test/unit/lib/Database/Query.test.ts
+++ b/test/unit/lib/Database/Query.test.ts
@@ -45,7 +45,8 @@ suite("Database/Query", () => {
       errorMessage: null,
       runAt: moment.utc("2017-01-03 00:00:00", "YYYY-MM-DD HH:mm:ss", true).local(),
       updatedAt: "2017-01-02 00:00:00",
-      createdAt: "2017-01-01 00:00:00"
+      createdAt: "2017-01-01 00:00:00",
+      history: null
     });
   });
 

--- a/test/unit/lib/Database/Query.test.ts
+++ b/test/unit/lib/Database/Query.test.ts
@@ -46,7 +46,7 @@ suite("Database/Query", () => {
       runAt: moment.utc("2017-01-03 00:00:00", "YYYY-MM-DD HH:mm:ss", true).local(),
       updatedAt: "2017-01-02 00:00:00",
       createdAt: "2017-01-01 00:00:00",
-      history: null
+      codeMirrorHistory: null
     });
   });
 


### PR DESCRIPTION
- Add `codeMirrorHistory` column to DB `queries` table
    - Store query editor history to query database
- Prevent undo clears editor

----

クエリ間・別ページに移動したときにもエディタの履歴 (undo / redo) が残せるようにしました。

- `queries` テーブルに `codeMirrorHistory` カラムを追加
    - エディタの履歴が[CodeMirrorの履歴](https://codemirror.net/doc/manual.html#getHistory)で取れるので、それをJSONで保存します
- （クエリを切り替えたときなど）Undoするとクエリが空状態にまでなるのを防ぐようにしました