### PR TITLE
Change Ctrl-K and Ctrl-Y motions as macOS native

### DIFF
--- a/src/renderer/components/Editor/Editor.tsx
+++ b/src/renderer/components/Editor/Editor.tsx
@@ -62,26 +62,22 @@ export default class Editor extends React.Component<Props> {
     if (process.platform === "darwin") {
       this.codeMirror.addKeyMap({
         ["Ctrl-K"]: (cm: CodeMirror.Editor) => {
-          if (process.platform === "darwin") {
-            if (!cm.somethingSelected()) {
-              const cursor = cm.getCursor();
-              const line = cm.getLine(cursor.line);
-              if (cursor.ch === line.length) {
-                cm.setSelection(cursor, { line: cursor.line + 1, ch: 0 });
-              } else {
-                cm.setSelection(cursor, { line: cursor.line, ch: line.length });
-              }
+          if (!cm.somethingSelected()) {
+            const cursor = cm.getCursor();
+            const line = cm.getLine(cursor.line);
+            if (cursor.ch === line.length) {
+              cm.setSelection(cursor, { line: cursor.line + 1, ch: 0 });
+            } else {
+              cm.setSelection(cursor, { line: cursor.line, ch: line.length });
             }
-            clipboard.writeFindText(cm.getSelection());
-            cm.replaceSelection("");
           }
+          clipboard.writeFindText(cm.getSelection());
+          cm.replaceSelection("");
         },
         ["Ctrl-Y"]: cm => {
-          if (process.platform === "darwin") {
-            const killBuffer = clipboard.readFindText();
-            if (killBuffer.length > 0) {
-              cm.replaceSelection(killBuffer);
-            }
+          const killBuffer = clipboard.readFindText();
+          if (killBuffer.length > 0) {
+            cm.replaceSelection(killBuffer);
           }
         }
       });

--- a/src/renderer/components/Editor/Editor.tsx
+++ b/src/renderer/components/Editor/Editor.tsx
@@ -10,6 +10,7 @@ import "codemirror/mode/sql/sql";
 import "codemirror/lib/codemirror.css";
 import "codemirror/addon/dialog/dialog.css";
 import { isEqual } from "lodash";
+import { clipboard } from "electron";
 
 type Props = {
   readonly options: CodeMirror.EditorConfiguration;
@@ -58,6 +59,33 @@ export default class Editor extends React.Component<Props> {
         }
       }
     });
+    if (process.platform === "darwin") {
+      this.codeMirror.addKeyMap({
+        ["Ctrl-K"]: (cm: CodeMirror.Editor) => {
+          if (process.platform === "darwin") {
+            if (!cm.somethingSelected()) {
+              const cursor = cm.getCursor();
+              const line = cm.getLine(cursor.line);
+              if (cursor.ch === line.length) {
+                cm.setSelection(cursor, { line: cursor.line + 1, ch: 0 });
+              } else {
+                cm.setSelection(cursor, { line: cursor.line, ch: line.length });
+              }
+            }
+            clipboard.writeFindText(cm.getSelection());
+            cm.replaceSelection("");
+          }
+        },
+        ["Ctrl-Y"]: cm => {
+          if (process.platform === "darwin") {
+            const killBuffer = clipboard.readFindText();
+            if (killBuffer.length > 0) {
+              cm.replaceSelection(killBuffer);
+            }
+          }
+        }
+      });
+    }
     this.currentValue = this.props.value;
     this.currentOptions = this.props.options;
     this.codeMirror.setValue(this.currentValue);


### PR DESCRIPTION
This Pull Request fixes Ctrl-K / Ctrl-Y behaviors like macOS:

- Ctrl-K removes the text from the selected string or cursor to the end of the line.
- Ctrl-Y do nothing

After

- Ctrl-K cuts the text from the selected string or cursor to the end of the line.
- Ctrl-Y pastes from buffer from Ctrl-K.

The copied text is stored separately from the OS's standard clipboard.
I couldn't find a way to store it to macOS from JavaScript, so I used [Electron's clipboard feature](https://www.electronjs.org/docs/api/clipboard).

----
macOSでCtrl-K / Ctrl-YをOS標準ぽい挙動になるようにしました。

- Ctrl-K 選択された文字列もしくはカーソル位置から行末までを削除します。
- Ctrl-Y: 選択位置にCtrl-Kでカットした文字列をペーストします。

コピーした文字列はOS標準のクリップボードとは別に保存されます。
ただJavaScriptから保存する方法が見つからなかったのでElectronのclipboardを使いました。
https://www.electronjs.org/docs/api/clipboard#clipboardreadfindtext-macos にあるreadFindTextをとりあえず使ってみましたが、Editor.tsxのメンバ変数でも良かったかもしれません。（writeFindText/readFindTextだと一応Editorコンポーネント以外からも読めるメリットはあるかもしれない）

Ctrl-Kのときの挙動は上書きする前のCodeMirrorオリジナルのものを参考にしています（行末まで「削除」）。
https://github.com/codemirror/CodeMirror/blob/5.55.0/src/edit/commands.js#L18-L28

このPull Requestは文字列複数選択への対応は不完全です。
Optionを押しながら選択したときの複数行選択状態になっている場合、Ctrl-KによるカットはできますがCtrl-Yによるペーストは不自然に見えるかもしれません。