### PR TITLE
Add checkbox to select share on gist in public or secret

### DIFF
--- a/src/lib/GitHubApiClient.ts
+++ b/src/lib/GitHubApiClient.ts
@@ -56,7 +56,7 @@ export default class GitHubApiClient {
     const response = await fetch(this.getGistUrl(), {
       method: "POST",
       headers: this.getHeaders(),
-      body: JSON.stringify(Object.assign({ public: false }, contents))
+      body: JSON.stringify(contents)
     });
 
     if (!response.ok) {

--- a/src/lib/QuerySharing.ts
+++ b/src/lib/QuerySharing.ts
@@ -52,7 +52,7 @@ export default {
     }
 
     const client = new GitHubApiClient(setting);
-    const result = await client.postToGist({ description, files });
+    const result = await client.postToGist({ description, files, public: setting.public });
 
     await electron.shell.openExternal(result.html_url);
   },

--- a/src/lib/Setting.ts
+++ b/src/lib/Setting.ts
@@ -12,6 +12,7 @@ export type SettingType = {
 export type GithubSettingType = {
   readonly token: string | null;
   readonly url: string | null;
+  readonly public: boolean;
   readonly maximumNumberOfRowsOfGist: number;
 };
 
@@ -26,6 +27,7 @@ export default class Setting {
       github: {
         token: null,
         url: null,
+        public: false,
         maximumNumberOfRowsOfGist: 10000
       },
       defaultDataSourceId: undefined

--- a/src/renderer/pages/Setting/Setting.tsx
+++ b/src/renderer/pages/Setting/Setting.tsx
@@ -77,6 +77,14 @@ class Setting extends React.Component<unknown, SettingState> {
             </Button>
             {this.renderGithubValidateTokenResult()}
           </div>
+          <div className="page-Setting-section2 page-Setting-public">
+            <h2>Share on gist in public</h2>
+            <input
+              type="checkbox"
+              onChange={(e): void => Action.update({ github: { public: e.target.checked } })}
+              checked={setting.github.public}
+            />
+          </div>
           <div className="page-Setting-section2">
             <h2>Maximum number of rows</h2>
             <input


### PR DESCRIPTION
closes #138
This pull request adds checkbox in Setting component to decide share gist in public or secret.
Default is `share gist in secret` (= same as current version).

Screenshot

![image](https://user-images.githubusercontent.com/1213991/87223430-d8aefe80-c3b7-11ea-8200-4eb0624944a6.png)
