### PR TITLE
Add simple auto completion for table name

### DIFF
--- a/src/lib/DataSourceDefinition/SQLite3.ts
+++ b/src/lib/DataSourceDefinition/SQLite3.ts
@@ -26,9 +26,6 @@ export default class SQLite3 extends Base {
 
   async fetchTables(): Promise<{ name: string; type: string; schema?: string }[]> {
     const { rows }: any = await this._execute("select tbl_name from sqlite_master where type = 'table'");
-    if (!rows) {
-      return Promise.resolve([]);
-    }
     return rows.map(row => {
       return { name: row[0], type: "table" };
     });

--- a/src/lib/DataSourceDefinition/SQLite3.ts
+++ b/src/lib/DataSourceDefinition/SQLite3.ts
@@ -26,6 +26,9 @@ export default class SQLite3 extends Base {
 
   async fetchTables(): Promise<{ name: string; type: string; schema?: string }[]> {
     const { rows }: any = await this._execute("select tbl_name from sqlite_master where type = 'table'");
+    if (!rows) {
+      return Promise.resolve([]);
+    }
     return rows.map(row => {
       return { name: row[0], type: "table" };
     });

--- a/src/renderer/components/QueryEditor/QueryEditor.tsx
+++ b/src/renderer/components/QueryEditor/QueryEditor.tsx
@@ -4,11 +4,13 @@ import Editor from "../Editor";
 import { SettingType } from "../../../lib/Setting";
 import { EditorConfiguration } from "codemirror";
 import { QueryType } from "../../../lib/Database/Query";
+import { TableType } from "src/renderer/pages/DataSource/DataSourceStore";
 
 type Props = {
   readonly editor: { line: number | null };
   readonly setting: SettingType;
   readonly query: QueryType;
+  readonly tables: TableType[];
   readonly mimeType: string;
   readonly onCancel: () => void;
   readonly onExecute: () => void;
@@ -98,11 +100,13 @@ export default class QueryEditor extends React.Component<Props> {
 
   render(): React.ReactNode {
     const query = this.props.query;
+    const tables: string[] = this.props.tables.map(table => table.name);
 
     return (
       <div className="QueryEditor">
         <Editor
           value={query.body || ""}
+          tables={tables}
           rootRef={(node): void => (this.editorElement = node)}
           onChange={this.props.onChangeQueryBody}
           onChangeCursor={this.props.onChangeCursorPosition}

--- a/src/renderer/pages/DataSource/DataSourceAction.ts
+++ b/src/renderer/pages/DataSource/DataSourceAction.ts
@@ -15,7 +15,7 @@ const DataSourceAction = {
   },
 
   async loadTables(dataSource: DataSourceType): Promise<void> {
-    let tables;
+    let tables: { name: string; type: string; fields?: string[]; schema?: string }[];
     try {
       tables = await DataSource.create(dataSource).fetchTables();
     } catch (e) {

--- a/src/renderer/pages/Query/Query.tsx
+++ b/src/renderer/pages/Query/Query.tsx
@@ -94,7 +94,7 @@ class Query extends React.Component<unknown, QueryState> {
         >
           <QueryEditor
             query={query}
-            tables={dataSource?.tables || []}
+            tables={dataSource?.tables ?? []}
             mimeType={dataSource?.mimeType ?? "text/x-sql"}
             {...this.state}
             onChangeQueryBody={(body, codeMirrorHistory): void => {

--- a/src/renderer/pages/Query/Query.tsx
+++ b/src/renderer/pages/Query/Query.tsx
@@ -94,6 +94,7 @@ class Query extends React.Component<unknown, QueryState> {
         >
           <QueryEditor
             query={query}
+            tables={dataSource?.tables || []}
             mimeType={dataSource?.mimeType ?? "text/x-sql"}
             {...this.state}
             onChangeQueryBody={(body, codeMirrorHistory): void => {

--- a/src/renderer/pages/Query/QueryAction.ts
+++ b/src/renderer/pages/Query/QueryAction.ts
@@ -17,9 +17,25 @@ const QueryAction = {
       Database.Chart.getAll()
     ]);
 
+    const dataSourceWithTables = await Promise.all(
+      dataSources.map(async dataSource => {
+        const ds = DataSource.create(dataSource);
+        try {
+          const tables = await ds.fetchTables();
+          return {
+            ...dataSource,
+            tables
+          };
+        } catch (e) {
+          console.log(`Failed to load tables from dataSource "${dataSource.name}"`, e);
+          return dataSource;
+        }
+      })
+    );
+
     dispatch("initialize", {
       queries,
-      dataSources,
+      dataSources: dataSourceWithTables,
       charts,
       setting: setting.load()
     });


### PR DESCRIPTION
![bdash_auto_complete](https://user-images.githubusercontent.com/1213991/88268340-3ffc7500-cd0d-11ea-8b86-094d358d9fbc.gif)

Implement very simple auto suggest feature.

- After 400 msec from query changed, table names are suggested.
- You can change the selection of suggestions by Ctrl-n / Ctrl-p (emacs-like).
- You can close suggestions by ESC.

Limitation:

- Use only table name for suggestion.
- Doesn't consider the context of query.
