### PR TITLE
Disable to get all tables of all DataSources while app initializing

### DIFF
--- a/src/renderer/pages/Query/QueryAction.ts
+++ b/src/renderer/pages/Query/QueryAction.ts
@@ -17,7 +17,17 @@ const QueryAction = {
       Database.Chart.getAll()
     ]);
 
-    const dataSourceWithTables = await Promise.all(
+    dispatch("initialize", {
+      queries,
+      dataSources,
+      charts,
+      setting: setting.load()
+    });
+  },
+
+  async dataSourceWithTables(): Promise<DataSourceType[]> {
+    const dataSources = await Database.DataSource.getAll();
+    return Promise.all(
       dataSources.map(async dataSource => {
         const ds = DataSource.create(dataSource);
         try {
@@ -32,13 +42,6 @@ const QueryAction = {
         }
       })
     );
-
-    dispatch("initialize", {
-      queries,
-      dataSources: dataSourceWithTables,
-      charts,
-      setting: setting.load()
-    });
   },
 
   async selectQuery(query: QueryType): Promise<void> {


### PR DESCRIPTION
#143 adds table name autocompletion, but it increases a wait while app is initializing.
We should use lazy load (background loading table names from DataSource while user selects a query).

For now, I disable #143.