### PR TITLE
Fix yaml dump error

### DIFF
--- a/src/lib/Setting.ts
+++ b/src/lib/Setting.ts
@@ -6,7 +6,7 @@ export type SettingType = {
   readonly keyBind: "default" | "vim";
   readonly lineWrap: boolean;
   readonly github: GithubSettingType;
-  readonly defaultDataSourceId?: number;
+  readonly defaultDataSourceId: number | null;
 };
 
 export type GithubSettingType = {
@@ -30,7 +30,7 @@ export default class Setting {
         public: false,
         maximumNumberOfRowsOfGist: 10000
       },
-      defaultDataSourceId: undefined
+      defaultDataSourceId: null
     };
   }
 

--- a/src/renderer/pages/Query/Query.tsx
+++ b/src/renderer/pages/Query/Query.tsx
@@ -17,9 +17,8 @@ class Query extends React.Component<unknown, QueryState> {
   }
 
   handleAddQuery(): void {
-    const defaultDataSourceId: number | undefined = this.state.setting.defaultDataSourceId;
-    const ds =
-      defaultDataSourceId !== undefined ? this.findDataSourceById(defaultDataSourceId) : this.state.dataSources[0];
+    const defaultDataSourceId = this.state.setting.defaultDataSourceId;
+    const ds = defaultDataSourceId !== null ? this.findDataSourceById(defaultDataSourceId) : this.state.dataSources[0];
     if (ds) {
       Action.addNewQuery({ dataSourceId: ds.id });
     } else {


### PR DESCRIPTION
`yaml.safeDump` throws an exception if the value is undefined 😰

```
> require('js-yaml').safeDump({ foo: undefined })
Uncaught:
YAMLException: unacceptable kind of an object to dump [object Undefined]
    at writeNode (/Users/kazuhito-hokamura/local/src/github.com/bdash-app/bdash/node_modules/js-yaml/lib/js-yaml/dumper.js:748:13)
    at writeBlockMapping (/Users/kazuhito-hokamura/local/src/github.com/bdash-app/bdash/node_modules/js-yaml/lib/js-yaml/dumper.js:627:10)
    at writeNode (/Users/kazuhito-hokamura/local/src/github.com/bdash-app/bdash/node_modules/js-yaml/lib/js-yaml/dumper.js:720:9)
    at dump (/Users/kazuhito-hokamura/local/src/github.com/bdash-app/bdash/node_modules/js-yaml/lib/js-yaml/dumper.js:809:7)
    at Object.safeDump (/Users/kazuhito-hokamura/local/src/github.com/bdash-app/bdash/node_modules/js-yaml/lib/js-yaml/dumper.js:815:10) {
  reason: 'unacceptable kind of an object to dump [object Undefined]',
  mark: undefined
}
> require('js-yaml').safeDump({ foo: null })
'foo: null\n'
```