### PR TITLE
Add about menu to Windows/Linux platform

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -24,6 +24,9 @@ publish:
     acl: public-read
     path: v${version}
 
+extraResources:
+  - build/icon.png
+
 win:
   target:
     - nsis

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -2,6 +2,7 @@ import { app, Menu, dialog, shell } from "electron";
 import { updater, UpdateState } from "./updater";
 import isDev from "electron-is-dev";
 import { createWindow } from "./window";
+import path from "path";
 
 const editMenu: Electron.MenuItemConstructorOptions = {
   label: "Edit",
@@ -90,6 +91,8 @@ if (process.platform === "darwin") {
     ]
   });
 } else if (Array.isArray(helpMenu.submenu)) {
+  helpMenu.submenu.push({ type: "separator" });
+  helpMenu.submenu.push({ role: "about" });
   helpMenu.submenu.push(checkForUpdateItem);
   template.unshift({
     label: "File",
@@ -98,6 +101,14 @@ if (process.platform === "darwin") {
 }
 
 export function initMenu(): void {
+  const iconPath = isDev
+    ? path.join(__dirname, "..", "..", "..", "build", "icon.png")
+    : path.join(process.resourcesPath, "build", "icon.png");
+  app.setAboutPanelOptions({
+    applicationName: "Bdash",
+    applicationVersion: app.getVersion(),
+    iconPath
+  });
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
 }


### PR DESCRIPTION
This PR adds a common about menu to see installed version information.

![image](https://user-images.githubusercontent.com/69755/118987708-78b3bc00-b9bb-11eb-94d6-2066848af58d.png)
![image](https://user-images.githubusercontent.com/69755/118987742-7fdaca00-b9bb-11eb-9cc3-27059ee0418c.png)
