### PR TITLE
Enable group by for multiple fields

### DIFF
--- a/src/lib/Database/Chart.ts
+++ b/src/lib/Database/Chart.ts
@@ -6,7 +6,7 @@ export type ChartType = {
   readonly type: "line" | "bar" | "area" | "pie";
   readonly xColumn: string;
   readonly yColumns: Array<string>;
-  readonly groupColumn: string;
+  readonly groupColumns: Array<string>;
   readonly stacking: 0 | string;
   readonly updatedAt: string;
   readonly createdAt: string;
@@ -54,7 +54,7 @@ export default class Chart {
 
     Object.keys(params).forEach(field => {
       fields.push(field);
-      values.push(field === "yColumns" ? JSON.stringify(params[field]) : params[field]);
+      values.push(["yColumns", "groupColumns"].includes(field) ? JSON.stringify(params[field]) : params[field]);
     });
     values.push(id);
 
@@ -71,5 +71,6 @@ export default class Chart {
 
 function convert(row): ChartType {
   const yColumns = JSON.parse(row.yColumns || "[]");
-  return Object.assign(row, { yColumns });
+  const groupColumns = JSON.parse(row.groupColumns || "[]");
+  return Object.assign(row, { yColumns, groupColumns });
 }

--- a/src/lib/Database/schema.ts
+++ b/src/lib/Database/schema.ts
@@ -15,7 +15,7 @@ export const migrations: Migration[] = [
       createdAt datetime not null,
       updatedAt datetime not null
     );
-    
+
     create table if not exists queries (
       id integer primary key autoincrement,
       dataSourceId integer not null references data_sources(id),
@@ -30,7 +30,7 @@ export const migrations: Migration[] = [
       createdAt datetime not null,
       updatedAt datetime not null
     );
-    
+
     create table if not exists charts (
       id integer primary key autoincrement,
       queryId integer not null references queries(id) on delete cascade,
@@ -48,5 +48,29 @@ export const migrations: Migration[] = [
   {
     version: 2,
     query: `alter table queries add column codeMirrorHistory json`
+  },
+  {
+    version: 3,
+    query: `
+      create table charts_backup (
+        id integer primary key autoincrement,
+        queryId integer not null references queries(id) on delete cascade,
+        type text not null,
+        xColumn text,
+        yColumns json,
+        groupColumns json,
+        stacking boolean not null default 0,
+        createdAt datetime not null,
+        updatedAt datetime not null
+      );
+
+      insert into charts_backup select
+        id, queryId, type, xColumn, yColumns, (case when groupColumn is null then null else json_array(groupColumn) end), stacking, createdAt, updatedAt
+      from charts;
+
+      drop table charts;
+      alter table charts_backup rename to charts;
+      create index if not exists idx_query_id_on_charts on charts(queryId);
+    `
   }
 ];

--- a/src/lib/QuerySharing.ts
+++ b/src/lib/QuerySharing.ts
@@ -162,7 +162,7 @@ function getChartAsSvg(query: QueryType, chart: ChartType | undefined, width: nu
     x: chart.xColumn,
     y: chart.yColumns,
     stacking: chart.stacking,
-    groupBy: chart.groupColumn,
+    groupBy: chart.groupColumns,
     rows: query.rows,
     fields: query.fields
   };

--- a/src/renderer/components/QueryResultChart/QueryResultChart.css
+++ b/src/renderer/components/QueryResultChart/QueryResultChart.css
@@ -12,7 +12,7 @@
   margin-bottom: 15px;
 }
 
-.-label {
+.QueryResultChart-label {
   font-size: 12px;
   font-weight: bold;
   color: #666;

--- a/src/renderer/components/QueryResultChart/QueryResultChart.css
+++ b/src/renderer/components/QueryResultChart/QueryResultChart.css
@@ -12,7 +12,7 @@
   margin-bottom: 15px;
 }
 
-.QueryResultChart-label {
+.-label {
   font-size: 12px;
   font-weight: bold;
   color: #666;

--- a/src/renderer/components/QueryResultChart/QueryResultChart.tsx
+++ b/src/renderer/components/QueryResultChart/QueryResultChart.tsx
@@ -44,7 +44,7 @@ export default class QueryResultChart extends React.Component<Props> {
       x: chart.xColumn,
       y: chart.yColumns,
       stacking: chart.stacking,
-      groupBy: chart.groupColumn,
+      groupBy: chart.groupColumns,
       rows: query.rows,
       fields: query.fields
     };
@@ -80,8 +80,8 @@ export default class QueryResultChart extends React.Component<Props> {
     this.update({ stacking: option.value });
   }
 
-  handleChangeGroup(option: OptionType): void {
-    this.update({ groupColumn: option ? option.value : null });
+  handleChangeGroup(options: ValueType<OptionTypeBase>): void {
+    this.update({ groupColumns: options && Array.isArray(options) ? options.map(o => o.value) : [] });
   }
 
   renderChartImage(chartType: string): React.ReactNode {
@@ -136,7 +136,7 @@ export default class QueryResultChart extends React.Component<Props> {
     }));
     const currentXColumnFieldOption = fieldOptions.find(option => option.value === chart.xColumn);
     const currentYColumnFieldOptions = fieldOptions.filter(option => chart.yColumns.includes(option.value));
-    const currentGroupOption = fieldOptions.find(option => option.value === chart.groupColumn);
+    const currentGroupOptions = fieldOptions.filter(option => chart.groupColumns.includes(option.value));
     const stackingOptions = ["disable", "enable", "percent"].map(o => ({
       label: o,
       value: o
@@ -194,8 +194,9 @@ export default class QueryResultChart extends React.Component<Props> {
           <div className="QueryResultChart-item" hidden={chart.type === "pie"}>
             <div className="QueryResultChart-label">Group By</div>
             <Select
+              isMulti={true}
               options={fieldOptions}
-              value={currentGroupOption}
+              value={currentGroupOptions}
               onChange={(o): void => this.handleChangeGroup(o)}
               isClearable={true}
               styles={selectStyles}

--- a/test/unit/lib/Database/Chart.test.ts
+++ b/test/unit/lib/Database/Chart.test.ts
@@ -9,9 +9,9 @@ suite("Database/Chart", () => {
   test("findAll", async () => {
     await connection.exec(`
       insert into charts
-        (id, queryId, type, xColumn, yColumns, groupColumn, stacking, updatedAt, createdAt)
+        (id, queryId, type, xColumn, yColumns, groupColumns, stacking, updatedAt, createdAt)
       values
-        (1, 100, 'bar', 'x', '["a","b"]', "g", 1, '2017-02-01 00:00:00', '2017-01-01 00:00:00')
+        (1, 100, 'bar', 'x', '["a","b"]', '["g"]', 1, '2017-02-01 00:00:00', '2017-01-01 00:00:00')
     `);
     const rows = await Chart.getAll();
     assert.deepStrictEqual(rows, [
@@ -21,7 +21,7 @@ suite("Database/Chart", () => {
         type: "bar",
         xColumn: "x",
         yColumns: ["a", "b"],
-        groupColumn: "g",
+        groupColumns: ["g"],
         stacking: 1,
         updatedAt: "2017-02-01 00:00:00",
         createdAt: "2017-01-01 00:00:00"
@@ -32,9 +32,9 @@ suite("Database/Chart", () => {
   test("get", async () => {
     await connection.exec(`
       insert into charts
-        (id, queryId, type, xColumn, yColumns, groupColumn, stacking, updatedAt, createdAt)
+        (id, queryId, type, xColumn, yColumns, groupColumns, stacking, updatedAt, createdAt)
       values
-        (1, 100, 'bar', 'x', '["a","b"]', "g", 1, '2017-02-01 00:00:00', '2017-01-01 00:00:00')
+        (1, 100, 'bar', 'x', '["a","b"]', '["g"]', 1, '2017-02-01 00:00:00', '2017-01-01 00:00:00')
     `);
     const rows = await Chart.get(1);
     assert.deepStrictEqual(rows, {
@@ -43,7 +43,7 @@ suite("Database/Chart", () => {
       type: "bar",
       xColumn: "x",
       yColumns: ["a", "b"],
-      groupColumn: "g",
+      groupColumns: ["g"],
       stacking: 1,
       updatedAt: "2017-02-01 00:00:00",
       createdAt: "2017-01-01 00:00:00"
@@ -74,9 +74,9 @@ suite("Database/Chart", () => {
   test("update", async () => {
     await connection.exec(`
       insert into charts
-        (id, queryId, type, xColumn, yColumns, groupColumn, stacking, updatedAt, createdAt)
+        (id, queryId, type, xColumn, yColumns, groupColumns, stacking, updatedAt, createdAt)
       values
-        (1, 100, 'bar', 'x', '["a","b"]', "g", 1, '2017-02-01 00:00:00', '2017-01-01 00:00:00')
+        (1, 100, 'bar', 'x', '["a","b"]', '["g"]', 1, '2017-02-01 00:00:00', '2017-01-01 00:00:00')
     `);
     const chart = await Chart.update(1, {
       xColumn: "new",


### PR DESCRIPTION
This PR enables multiple fields to be selected for the group by option of the chart. 

Let ![](https://render.githubusercontent.com/render/math?math=a,%20b,%20...,%20n) be vectors representing the group by values. Then, a separate line is created for every item in the cartesian product of ![](https://render.githubusercontent.com/render/math?math=a,%20b,%20...,%20n), i.e.

![](https://render.githubusercontent.com/render/math?math=(a_i,%20b_j,%20...,%20n_k)%20\in%20a%20\times%20b%20\times%20...%20\times%20n)

where

![](https://render.githubusercontent.com/render/math?math=a_i%20\in%20a,%20b_j%20\in%20b,%20...,%20n_k%20\in%20n)

such that the pair has at least one entry in `rows`.

![image](https://user-images.githubusercontent.com/28969934/131124553-d68cbcd9-a4ab-4d58-9d9c-12e8a8f1be5c.png)

