### PR TITLE
Follow pagination of Athena query results

### DIFF
--- a/src/lib/AthenaClient.ts
+++ b/src/lib/AthenaClient.ts
@@ -56,7 +56,7 @@ export default class AthenaClient {
 
     let rows = [];
     let nextToken: string | undefined = undefined;
-    while (true) {
+    for (;;) {
       const result = await this.getQueryResults(this.executionId, nextToken);
       nextToken = result.NextToken;
       const rs = ((result.ResultSet && result.ResultSet.Rows) || []).map(r => {

--- a/src/lib/AthenaClient.ts
+++ b/src/lib/AthenaClient.ts
@@ -54,11 +54,21 @@ export default class AthenaClient {
       }
     });
 
-    const { ResultSet } = await this.getQueryResults(this.executionId);
+    let rows = [];
+    let nextToken: string | undefined = undefined;
+    while (true) {
+      const result = await this.getQueryResults(this.executionId, nextToken);
+      nextToken = result.NextToken;
+      const rs = ((result.ResultSet && result.ResultSet.Rows) || []).map(r => {
+        return ((r && r.Data) || []).map(d => (d.VarCharValue === undefined ? null : d.VarCharValue));
+      });
+      rows = rows.concat(rs);
+      if (!nextToken) {
+        break;
+      }
+    }
 
-    return ((ResultSet && ResultSet.Rows) || []).map(r => {
-      return ((r && r.Data) || []).map(d => (d.VarCharValue === undefined ? null : d.VarCharValue));
-    });
+    return rows;
   }
 
   cancel(): void {
@@ -91,9 +101,9 @@ export default class AthenaClient {
     });
   }
 
-  private async getQueryResults(id: string): Promise<Athena.GetQueryResultsOutput> {
+  private async getQueryResults(id: string, nextToken: string | undefined): Promise<Athena.GetQueryResultsOutput> {
     return new Promise((resolve, reject) => {
-      this.client.getQueryResults({ QueryExecutionId: id }, (err, data) => {
+      this.client.getQueryResults({ QueryExecutionId: id, NextToken: nextToken }, (err, data) => {
         if (err) {
           reject(err);
         } else {


### PR DESCRIPTION
GetQueryResults API only returns up to 1000 rows. So pagination is
required to get more rows.
https://docs.aws.amazon.com/athena/latest/APIReference/API_GetQueryResults.html

## Before
![image](https://user-images.githubusercontent.com/69755/149176977-352cb5ee-534a-49ec-a488-1699b0894c7d.png)

## After
![image](https://user-images.githubusercontent.com/69755/149176863-3adc17d3-bbd0-47ed-9af0-d9be730574ea.png)
