### PR TITLE
Send also chart information to bdash-server

### DIFF
--- a/src/lib/QuerySharing.ts
+++ b/src/lib/QuerySharing.ts
@@ -105,6 +105,10 @@ export default {
       files["chart.svg"] = { content: svg };
     }
 
+    if (chart) {
+      files["chart.json"] = { content: JSON.stringify(chart) };
+    }
+
     const client = new BdashServerClient(setting);
     const result = await client.post({ description, files });
 


### PR DESCRIPTION
Added chart information to query sharing parameters in order for bdash-server to use the same logic as in Bdash.app to draw a chart.

See also: https://github.com/bdash-app/bdash-server/pull/16
