### PR TITLE
postgres: Skip TLS certificate verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/lodash": "4.14.157",
     "@types/mocha": "2.2.46",
     "@types/node": "12.12.12",
+    "@types/pg": "^8.6.4",
     "@types/plotly.js": "1.44.21",
     "@types/react": "~16.8.25",
     "@types/react-dom": "~16.8.5",

--- a/src/lib/DataSourceDefinition/Postgres.ts
+++ b/src/lib/DataSourceDefinition/Postgres.ts
@@ -112,7 +112,7 @@ export default class Postgres extends Base {
     }
 
     return new Promise((resolve, reject) => {
-      this.currentClient = new pg.Client(this.config);
+      this.currentClient = new pg.Client(this.getConfig());
       this.currentClient.connect((err) => {
         if (err) {
           this.currentClient.end();
@@ -145,5 +145,24 @@ export default class Postgres extends Base {
     }
 
     return new Error(message);
+  }
+
+  private getConfig(): pg.ClientConfig {
+    let ssl: pg.ClientConfig["ssl"] = undefined;
+    if (this.config.ssl) {
+      // Skipping verification is equivalent to sslmode=prefer and sslmode=require in libpq.
+      // https://www.postgresql.org/docs/14/libpq-ssl.html
+      // https://node-postgres.com/features/ssl
+      // rejectUnauthorized=false is also set in ./Mysql.ts if sslCaFilename is unset.
+      ssl = { rejectUnauthorized: false };
+    }
+    return {
+      host: this.config.host,
+      port: this.config.port,
+      user: this.config.user,
+      password: this.config.password,
+      database: this.config.database,
+      ssl,
+    };
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,6 +1195,15 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/pg@^8.6.4":
+  version "8.6.4"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.6.4.tgz#da1ae9d2f53f2dbfdd2b37e0eb478bf60d517f60"
+  integrity sha512-uYA7UMVzDFpJobCrqwW/iWkFmvizy6knIUgr0Quaw7K1Le3ZnF7hI3bKqFoxPZ+fju1Sc7zdTvOl9YfFZPcmeA==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
 "@types/plist@^3.0.1":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/plist/-/plist-3.0.2.tgz#61b3727bba0f5c462fe333542534a0c3e19ccb01"
@@ -5773,12 +5782,12 @@ pg-pool@^3.4.1:
   resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.4.1.tgz#0e71ce2c67b442a5e862a9c182172c37eda71e9c"
   integrity sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ==
 
-pg-protocol@^1.5.0:
+pg-protocol@*, pg-protocol@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.5.0.tgz#b5dd452257314565e2d54ab3c132adc46565a6a0"
   integrity sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==
 
-pg-types@^2.1.0:
+pg-types@^2.1.0, pg-types@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
   integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==


### PR DESCRIPTION
TLS certificate verification was skipped in pg 7.x but pg 8.x started to
default to rejectUnauthorized=true.
https://node-postgres.com/announcements#2020-02-25
This PR reverts TLS verification behavior back to Bdash < v1.12.0. MySQL
driver in Bdash also skips TLS verification if "SSL CA File" is not
specified.