### PR TITLE
Rewrite some class components to functional components

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -29,9 +29,12 @@ rules:
   '@typescript-eslint/no-non-null-assertion': off
   '@typescript-eslint/explicit-module-boundary-types': off
   'react/prop-types': off
+  'react-hooks/rules-of-hooks': error
+  'react-hooks/exhaustive-deps': warn
 
 plugins:
   - react
+  - react-hooks
 
 settings:
   react:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -28,6 +28,7 @@ rules:
   '@typescript-eslint/no-explicit-any': off
   '@typescript-eslint/no-non-null-assertion': off
   '@typescript-eslint/explicit-module-boundary-types': off
+  'react/prop-types': off
 
 plugins:
   - react

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "~7.20.0",
+    "eslint-plugin-react-hooks": "^4.5.0",
     "execa": "0.9.0",
     "mini-css-extract-plugin": "~1.4.1",
     "prettier": "^2.5.1",

--- a/src/renderer/components/Button/Button.tsx
+++ b/src/renderer/components/Button/Button.tsx
@@ -5,19 +5,12 @@ interface ButtonProps {
   readonly className?: string;
 }
 
-export default class Button extends React.Component<ButtonProps> {
-  handleClick(e: React.MouseEvent<HTMLSpanElement>): void {
-    if (this.props.onClick) {
-      this.props.onClick(e);
-    }
-  }
+const Button = React.memo<React.PropsWithChildren<ButtonProps>>(function Button({ onClick, className, children }) {
+  return (
+    <span className={`${className || ""} Button`.trim()} onClick={onClick}>
+      {children}
+    </span>
+  );
+});
 
-  override render(): React.ReactNode {
-    const className = `${this.props.className || ""} Button`.trim();
-    return (
-      <span className={className} onClick={this.handleClick.bind(this)}>
-        {this.props.children}
-      </span>
-    );
-  }
-}
+export default Button;

--- a/src/renderer/components/DataSourceList/DataSourceList.tsx
+++ b/src/renderer/components/DataSourceList/DataSourceList.tsx
@@ -15,12 +15,22 @@ type Props = {
   readonly changeDefaultDataSourceId: (dataSourceId: number) => void;
 };
 
-export default class DataSourceList extends React.Component<Props> {
-  handleContextMenu(id: number): void {
-    if (id !== this.props.selectedDataSourceId) {
-      const dataSource = this.find(id);
+const DataSourceList: React.FC<Props> = ({
+  dataSources,
+  selectedDataSourceId,
+  defaultDataSourceId,
+  onClickNew,
+  onSelect,
+  onEdit,
+  onReload,
+  onDelete,
+  changeDefaultDataSourceId,
+}) => {
+  const handleContextMenu = (id: number): void => {
+    if (id !== selectedDataSourceId) {
+      const dataSource = find(id);
       if (dataSource) {
-        this.props.onSelect(this.props.dataSources[id]);
+        onSelect(dataSources[id]);
       }
     }
 
@@ -29,59 +39,58 @@ export default class DataSourceList extends React.Component<Props> {
         {
           label: "Edit",
           click: (): void => {
-            const dataSource = this.find(id);
+            const dataSource = find(id);
             if (dataSource) {
-              this.props.onEdit(dataSource);
+              onEdit(dataSource);
             }
           },
         },
         {
           label: "Reload",
           click: (): void => {
-            const dataSource = this.find(id);
+            const dataSource = find(id);
             if (dataSource) {
-              this.props.onReload(dataSource);
+              onReload(dataSource);
             }
           },
         },
         {
           label: "Set as default",
           type: "checkbox",
-          checked: id === this.props.defaultDataSourceId,
+          checked: id === defaultDataSourceId,
           click: (): void => {
-            this.props.changeDefaultDataSourceId(id);
+            changeDefaultDataSourceId(id);
           },
         },
         {
           label: "Delete",
           click: (): void => {
             if (window.confirm("Are you sure?")) {
-              this.props.onDelete(id);
+              onDelete(id);
             }
           },
         },
       ]);
       menu.popup({ window: remote.getCurrentWindow() });
     });
-  }
+  };
 
-  find(id: number): DataSourceType | undefined {
-    return this.props.dataSources.find((d) => d.id === id);
-  }
+  const find = (id: number): DataSourceType | undefined => {
+    return dataSources.find((d) => d.id === id);
+  };
 
-  override render(): React.ReactNode {
-    const items = this.props.dataSources.map((dataSource) => {
+  const render = (): React.ReactElement => {
+    const items = dataSources.map((dataSource) => {
       const className = classNames({
-        "is-selected": this.props.selectedDataSourceId === dataSource.id,
+        "is-selected": selectedDataSourceId === dataSource.id,
       });
-      const label: string =
-        dataSource.id === this.props.defaultDataSourceId ? dataSource.name + " (default)" : dataSource.name;
+      const label: string = dataSource.id === defaultDataSourceId ? dataSource.name + " (default)" : dataSource.name;
       return (
         <li
           key={dataSource.id}
           className={className}
-          onContextMenu={(): void => this.handleContextMenu(dataSource.id)}
-          onClick={(): void => this.props.onSelect(dataSource)}
+          onContextMenu={(): void => handleContextMenu(dataSource.id)}
+          onClick={(): void => onSelect(dataSource)}
         >
           {label}
         </li>
@@ -91,10 +100,14 @@ export default class DataSourceList extends React.Component<Props> {
     return (
       <div className="DataSourceList">
         <div className={classNames("DataSourceList-new", { darwin: process.platform === "darwin" })}>
-          <i className="fas fa-plus" onClick={this.props.onClickNew} />
+          <i className="fas fa-plus" onClick={onClickNew} />
         </div>
         <ul className="DataSourceList-list">{items}</ul>
       </div>
     );
-  }
-}
+  };
+
+  return render();
+};
+
+export default DataSourceList;

--- a/src/renderer/components/GlobalMenu/GlobalMenu.tsx
+++ b/src/renderer/components/GlobalMenu/GlobalMenu.tsx
@@ -6,31 +6,29 @@ type Props = {
   readonly selectedPage: string;
 };
 
-export default class GlobalMenu extends React.Component<Props> {
-  get menuList(): React.ReactNode {
+const GlobalMenu = React.memo<Props>(function GlobalMenu({ onSelect, selectedPage }) {
+  const menuList = ((): React.ReactNode => {
     return [
       { page: "query", icon: "terminal" },
       { page: "dataSource", icon: "database" },
       { page: "setting", icon: "cog" },
     ].map((item, idx) => {
-      const selected = this.props.selectedPage === item.page;
+      const selected = selectedPage === item.page;
       const className = classNames("GlobalMenu-item", `GlobalMenu-${item.page}`, {
         "is-selected": selected,
       });
 
       return (
-        <span className={className} onClick={(): void => this.handleClick(item.page)} key={idx}>
+        <span className={className} onClick={(): void => handleClick(item.page)} key={idx}>
           <i className={`fas fa-${item.icon}`} />
         </span>
       );
     });
-  }
+  })();
 
-  handleClick(page: string): void {
-    this.props.onSelect(page);
-  }
+  const handleClick = onSelect;
 
-  override render(): React.ReactNode {
-    return <div className="GlobalMenu">{this.menuList}</div>;
-  }
-}
+  return <div className="GlobalMenu">{menuList}</div>;
+});
+
+export default GlobalMenu;

--- a/src/renderer/components/LoadingIcon/LoadingIcon.tsx
+++ b/src/renderer/components/LoadingIcon/LoadingIcon.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-export default class LoadingIcon extends React.Component {
-  override render(): React.ReactNode {
-    return <i className="LoadingIcon fas fa-spin fa-sync" />;
-  }
-}
+const LoadingIcon = React.memo(function LoadingIcon() {
+  return <i className="LoadingIcon fas fa-spin fa-sync" />;
+});
+
+export default LoadingIcon;

--- a/src/renderer/components/ModalDialog/ModalDialog.tsx
+++ b/src/renderer/components/ModalDialog/ModalDialog.tsx
@@ -1,16 +1,20 @@
 import React from "react";
 import Modal from "react-modal";
 
-export default class ModalDialog extends React.Component<{ className?: string }> {
-  override render(): React.ReactNode {
-    const style = {
-      overlay: { backgroundColor: "transparent" },
-    };
+type Props = {
+  className?: string;
+};
 
-    return (
-      <Modal isOpen={true} style={style} className={`ModalDialog ${this.props.className ?? ""}`} ariaHideApp={false}>
-        {this.props.children}
-      </Modal>
-    );
-  }
-}
+const ModalDialog: React.FC<React.PropsWithChildren<Props>> = ({ className, children }) => {
+  const style = {
+    overlay: { backgroundColor: "transparent" },
+  };
+
+  return (
+    <Modal isOpen={true} style={style} className={`ModalDialog ${className ?? ""}`} ariaHideApp={false}>
+      {children}
+    </Modal>
+  );
+};
+
+export default ModalDialog;

--- a/src/renderer/components/QueryEditor/QueryEditor.tsx
+++ b/src/renderer/components/QueryEditor/QueryEditor.tsx
@@ -8,7 +8,6 @@ import { TableType } from "src/renderer/pages/DataSource/DataSourceStore";
 import { Language } from "@hokaccha/sql-formatter";
 
 type Props = {
-  readonly editor: { line: number | null };
   readonly setting: SettingType;
   readonly query: QueryType;
   readonly tables: TableType[];
@@ -16,58 +15,66 @@ type Props = {
   readonly formatType: Language;
   readonly onCancel: () => void;
   readonly onExecute: () => void;
-  readonly onChangeEditorHeight: (height: number) => void;
   readonly onChangeQueryBody: (body: string, codeMirrorHistory: Record<string, unknown>) => void;
   readonly onChangeCursorPosition: (lineNumber: number) => void;
 };
 
-export default class QueryEditor extends React.Component<Props> {
-  editorElement: HTMLDivElement;
+const QueryEditor: React.FC<Props> = ({
+  setting,
+  query,
+  tables,
+  mimeType,
+  formatType,
+  onCancel,
+  onExecute,
+  onChangeQueryBody,
+  onChangeCursorPosition,
+}) => {
+  const editorElementRef = React.useRef<HTMLDivElement>(null);
 
-  get options(): EditorConfiguration {
+  const options = React.useMemo((): EditorConfiguration => {
     return {
-      mode: this.props.mimeType,
-      keyMap: this.props.setting.keyBind,
+      mode: mimeType,
+      keyMap: setting.keyBind,
       lineNumbers: true,
-      lineWrapping: this.props.setting.lineWrap,
+      lineWrapping: setting.lineWrap,
       matchBrackets: true,
-      indentUnit: this.props.setting.indent,
+      indentUnit: setting.indent,
       smartIndent: false,
       autoRefresh: { delay: 50 },
     };
-  }
+  }, [mimeType, setting.indent, setting.keyBind, setting.lineWrap]);
 
-  renderButton(): React.ReactNode {
-    if (this.props.query.status === "working") {
+  const renderButton = (): React.ReactNode => {
+    if (query.status === "working") {
       return (
-        <Button className="QueryEditor-cancelBtn" onClick={this.props.onCancel}>
+        <Button className="QueryEditor-cancelBtn" onClick={onCancel}>
           Cancel
         </Button>
       );
     } else {
       return (
-        <Button className="QueryEditor-executeBtn" onClick={this.props.onExecute}>
+        <Button className="QueryEditor-executeBtn" onClick={onExecute}>
           Execute
         </Button>
       );
     }
-  }
+  };
 
-  renderStatus(): React.ReactNode {
-    switch (this.props.query.status) {
+  const renderStatus = (): React.ReactNode => {
+    switch (query.status) {
       case "success":
-        return this.renderSuccess();
+        return renderSuccess();
       case "failure":
-        return this.renderError();
+        return renderError();
       case "working":
-        return this.renderWorking();
+        return renderWorking();
       default:
         return null;
     }
-  }
+  };
 
-  renderSuccess(): React.ReactNode {
-    const query = this.props.query;
+  const renderSuccess = (): React.ReactNode => {
     return (
       <div className="QueryEditor-status">
         <span>
@@ -78,9 +85,9 @@ export default class QueryEditor extends React.Component<Props> {
         <span>rows: {query.rows ? query.rows.length : "-"}</span>
       </div>
     );
-  }
+  };
 
-  renderError(): React.ReactNode {
+  const renderError = (): React.ReactNode => {
     return (
       <div className="QueryEditor-status is-error">
         <span>
@@ -88,9 +95,9 @@ export default class QueryEditor extends React.Component<Props> {
         </span>
       </div>
     );
-  }
+  };
 
-  renderWorking(): React.ReactNode {
+  const renderWorking = (): React.ReactNode => {
     return (
       <div className="QueryEditor-status is-working">
         <span>
@@ -98,31 +105,34 @@ export default class QueryEditor extends React.Component<Props> {
         </span>
       </div>
     );
-  }
+  };
 
-  override render(): React.ReactNode {
-    const query = this.props.query;
-    const tables: string[] = this.props.tables.map((table) => table.name);
+  const render = (): React.ReactElement => {
+    const tableNames: string[] = tables.map((table) => table.name);
 
     return (
       <div className="QueryEditor">
         <Editor
           value={query.body || ""}
-          tables={tables}
-          formatType={this.props.formatType}
-          rootRef={(node): void => (this.editorElement = node)}
-          onChange={this.props.onChangeQueryBody}
-          onChangeCursor={this.props.onChangeCursorPosition}
-          onSubmit={this.props.onExecute}
-          options={this.options}
-          codeMirrorHistory={this.props.query.codeMirrorHistory ?? undefined}
-          setting={this.props.setting}
+          tables={tableNames}
+          formatType={formatType}
+          rootRef={editorElementRef}
+          onChange={onChangeQueryBody}
+          onChangeCursor={onChangeCursorPosition}
+          onSubmit={onExecute}
+          options={options}
+          codeMirrorHistory={query.codeMirrorHistory ?? undefined}
+          setting={setting}
         />
         <div className="QueryEditor-navbar">
-          {this.renderButton()}
-          {this.renderStatus()}
+          {renderButton()}
+          {renderStatus()}
         </div>
       </div>
     );
-  }
-}
+  };
+
+  return render();
+};
+
+export default QueryEditor;

--- a/src/renderer/components/QueryHeader/QueryHeader.tsx
+++ b/src/renderer/components/QueryHeader/QueryHeader.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Select from "react-select";
 import { selectStyles } from "../Select";
 import { QueryType } from "../../../lib/Database/Query";
-import { DataSourceType } from "../../../renderer/pages/DataSource/DataSourceStore";
+import { DataSourceType } from "../../pages/DataSource/DataSourceStore";
 
 type Props = {
   readonly query: QueryType;
@@ -11,40 +11,32 @@ type Props = {
   readonly onChangeDataSource: (dataSourceId: number) => void;
 };
 
-export default class QueryHeader extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-    this.handleChangeTitle = this.handleChangeTitle.bind(this);
-    this.handleChangeDataSource = this.handleChangeDataSource.bind(this);
-  }
+const QueryHeader: React.FC<Props> = ({ query, dataSources, onChangeTitle, onChangeDataSource }) => {
+  const handleChangeTitle = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    onChangeTitle(e.target.value);
+  };
 
-  handleChangeTitle(e: React.ChangeEvent<HTMLInputElement>): void {
-    this.props.onChangeTitle(e.target.value);
-  }
+  const handleChangeDataSource = React.useCallback(
+    (e: any): void => {
+      onChangeDataSource(e.value);
+    },
+    [onChangeDataSource]
+  );
 
-  handleChangeDataSource(e): void {
-    this.props.onChangeDataSource(e.value);
-  }
-
-  override render(): React.ReactNode {
-    const options = this.props.dataSources.map((dataSource) => {
+  const render = (): React.ReactElement => {
+    const options = dataSources.map((dataSource) => {
       return { value: dataSource.id, label: dataSource.name };
     });
-    const currentOption = options.find((option) => option.value === this.props.query.dataSourceId);
+    const currentOption = options.find((option) => option.value === query.dataSourceId);
 
     return (
       <div className="QueryHeader">
-        <input
-          className="QueryHeader-inputTitle"
-          type="text"
-          value={this.props.query.title}
-          onChange={this.handleChangeTitle}
-        />
+        <input className="QueryHeader-inputTitle" type="text" value={query.title} onChange={handleChangeTitle} />
         <Select
           className="QueryHeader-selectDataSource"
           value={currentOption}
           options={options}
-          onChange={this.handleChangeDataSource}
+          onChange={handleChangeDataSource}
           placeholder={"Select data source..."}
           isClearable={false}
           isSearchable={false}
@@ -52,5 +44,9 @@ export default class QueryHeader extends React.Component<Props> {
         />
       </div>
     );
-  }
-}
+  };
+
+  return render();
+};
+
+export default QueryHeader;

--- a/src/renderer/components/QueryList/QueryList.tsx
+++ b/src/renderer/components/QueryList/QueryList.tsx
@@ -12,54 +12,52 @@ type Props = {
   readonly onDeleteQuery: (queryId: number) => void;
 };
 
-export default class QueryList extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-    this.handleClickNew = this.handleClickNew.bind(this);
-  }
+const QueryList: React.FC<Props> = ({
+  queries,
+  selectedQueryId,
+  onAddQuery,
+  onSelectQuery,
+  onDuplicateQuery,
+  onDeleteQuery,
+}) => {
+  const handleClickNew = onAddQuery;
 
-  handleClickNew(): void {
-    this.props.onAddQuery();
-  }
+  const handleClickItem = onSelectQuery;
 
-  handleClickItem(query: QueryType): void {
-    this.props.onSelectQuery(query);
-  }
-
-  handleContextMenu(query: QueryType): void {
-    this.props.onSelectQuery(query);
+  const handleContextMenu = (query: QueryType): void => {
+    onSelectQuery(query);
     setImmediate(() => {
       const menu = remote.Menu.buildFromTemplate([
         {
           label: "Duplicate",
           click: (): void => {
-            this.props.onDuplicateQuery(query);
+            onDuplicateQuery(query);
           },
         },
         {
           label: "Delete",
           click: (): void => {
             if (window.confirm("Are you sure?")) {
-              this.props.onDeleteQuery(query.id);
+              onDeleteQuery(query.id);
             }
           },
         },
       ]);
       menu.popup({ window: remote.getCurrentWindow() });
     });
-  }
+  };
 
-  override render(): React.ReactNode {
-    const items = this.props.queries.map((query) => {
+  const render = (): React.ReactElement => {
+    const items = queries.map((query) => {
       const className = classNames({
-        "is-selected": this.props.selectedQueryId === query.id,
+        "is-selected": selectedQueryId === query.id,
       });
       return (
         <li
           key={query.id}
           className={className}
-          onClick={(): void => this.handleClickItem(query)}
-          onContextMenu={(): void => this.handleContextMenu(query)}
+          onClick={(): void => handleClickItem(query)}
+          onContextMenu={(): void => handleContextMenu(query)}
         >
           {query.title}
         </li>
@@ -69,10 +67,14 @@ export default class QueryList extends React.Component<Props> {
     return (
       <div className="QueryList">
         <div className={classNames("QueryList-new", { darwin: process.platform === "darwin" })}>
-          <i className="fas fa-plus" onClick={this.handleClickNew} />
+          <i className="fas fa-plus" onClick={handleClickNew} />
         </div>
         <ul className="QueryList-list">{items}</ul>
       </div>
     );
-  }
-}
+  };
+
+  return render();
+};
+
+export default QueryList;

--- a/src/renderer/components/QueryResult/QueryResult.tsx
+++ b/src/renderer/components/QueryResult/QueryResult.tsx
@@ -18,27 +18,28 @@ type Props = {
   readonly onUpdateChart: (id: number, params: any) => void;
 };
 
-export default class QueryResult extends React.Component<Props> {
-  renderError(): React.ReactNode {
-    return (
-      <div className="QueryResult">
-        <div className="QueryResult-errorMessage">{this.props.query.errorMessage}</div>
-      </div>
-    );
-  }
-
-  renderMain(): React.ReactNode {
-    if (this.props.query.selectedTab === "chart") {
-      const chart = this.props.charts.find((chart) => chart.queryId === this.props.query.id);
-      return <QueryResultChart chart={chart} {...this.props} />;
+const QueryResult: React.FC<Props> = ({
+  query,
+  charts,
+  onClickCopyAsJson,
+  onClickCopyAsTsv,
+  onClickCopyAsCsv,
+  onClickCopyAsMarkdown,
+  onClickShareOnGist,
+  onClickShareOnBdashServer,
+  onSelectTab,
+  onUpdateChart,
+}) => {
+  const renderMain = (): React.ReactNode => {
+    if (query.selectedTab === "chart") {
+      const chart = charts.find((chart) => chart.queryId === query.id);
+      return <QueryResultChart chart={chart} query={query} onUpdateChart={onUpdateChart} />;
     } else {
-      return <QueryResultTable {...this.props} />;
+      return <QueryResultTable query={query} />;
     }
-  }
+  };
 
-  override render(): React.ReactNode {
-    const query = this.props.query;
-
+  const render = (): React.ReactElement => {
     if (query.status === "failure") {
       return (
         <div className="QueryResult">
@@ -53,9 +54,22 @@ export default class QueryResult extends React.Component<Props> {
 
     return (
       <div className="QueryResult">
-        <QueryResultNav {...this.props} />
-        {this.renderMain()}
+        <QueryResultNav
+          query={query}
+          onClickCopyAsCsv={onClickCopyAsCsv}
+          onClickCopyAsJson={onClickCopyAsJson}
+          onClickCopyAsMarkdown={onClickCopyAsMarkdown}
+          onClickCopyAsTsv={onClickCopyAsTsv}
+          onClickShareOnBdashServer={onClickShareOnBdashServer}
+          onClickShareOnGist={onClickShareOnGist}
+          onSelectTab={onSelectTab}
+        />
+        {renderMain()}
       </div>
     );
-  }
-}
+  };
+
+  return render();
+};
+
+export default QueryResult;

--- a/src/renderer/components/QueryResultNav/QueryResultNav.tsx
+++ b/src/renderer/components/QueryResultNav/QueryResultNav.tsx
@@ -14,95 +14,95 @@ type Props = {
   readonly onSelectTab: (tabName: "table" | "chart") => void;
 };
 
-type State = {
-  readonly openShareFlyout: boolean;
-};
+const QueryResultNav = React.memo<Props>(function QueryResultNav({
+  query,
+  onClickCopyAsJson,
+  onClickCopyAsTsv,
+  onClickCopyAsCsv,
+  onClickCopyAsMarkdown,
+  onClickShareOnGist,
+  onClickShareOnBdashServer,
+  onSelectTab,
+}) {
+  const [openShareFlyout, setOpenShareFlyout] = React.useState(false);
 
-export default class QueryResultNav extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = { openShareFlyout: false };
-    this.handleClickCopyAsJson = this.handleClickCopyAsJson.bind(this);
-    this.handleClickCopyAsTsv = this.handleClickCopyAsTsv.bind(this);
-    this.handleClickCopyAsCsv = this.handleClickCopyAsCsv.bind(this);
-    this.handleClickCopyAsMarkdown = this.handleClickCopyAsMarkdown.bind(this);
-    this.handleClickShareOnGist = this.handleClickShareOnGist.bind(this);
-    this.handleClickShareOnBdashServer = this.handleClickShareOnBdashServer.bind(this);
-  }
+  const selectedTab = (name: string): boolean => {
+    return (query.selectedTab || "table") === name;
+  };
 
-  selectedTab(name: string): boolean {
-    return (this.props.query.selectedTab || "table") === name;
-  }
+  const handleClickCopyAsJson = (): void => {
+    setOpenShareFlyout(false);
+    onClickCopyAsJson();
+  };
 
-  handleClickCopyAsJson(): void {
-    this.setState({ openShareFlyout: false });
-    this.props.onClickCopyAsJson();
-  }
+  const handleClickCopyAsTsv = (): void => {
+    setOpenShareFlyout(false);
+    onClickCopyAsTsv();
+  };
 
-  handleClickCopyAsTsv(): void {
-    this.setState({ openShareFlyout: false });
-    this.props.onClickCopyAsTsv();
-  }
+  const handleClickCopyAsCsv = (): void => {
+    setOpenShareFlyout(false);
+    onClickCopyAsCsv();
+  };
 
-  handleClickCopyAsCsv(): void {
-    this.setState({ openShareFlyout: false });
-    this.props.onClickCopyAsCsv();
-  }
+  const handleClickCopyAsMarkdown = (): void => {
+    setOpenShareFlyout(false);
+    onClickCopyAsMarkdown();
+  };
 
-  handleClickCopyAsMarkdown(): void {
-    this.setState({ openShareFlyout: false });
-    this.props.onClickCopyAsMarkdown();
-  }
+  const handleClickShareOnGist = (): void => {
+    setOpenShareFlyout(false);
+    onClickShareOnGist();
+  };
 
-  handleClickShareOnGist(): void {
-    this.setState({ openShareFlyout: false });
-    this.props.onClickShareOnGist();
-  }
+  const handleClickShareOnBdashServer = (): void => {
+    setOpenShareFlyout(false);
+    onClickShareOnBdashServer();
+  };
 
-  handleClickShareOnBdashServer(): void {
-    this.setState({ openShareFlyout: false });
-    this.props.onClickShareOnBdashServer();
-  }
-
-  override render(): React.ReactNode {
+  const render = (): React.ReactElement => {
     return (
       <div className="QueryResultNav">
         <span
           className={classNames("QueryResultNav-tabMenu", {
-            "is-selected": this.selectedTab("table"),
+            "is-selected": selectedTab("table"),
           })}
-          onClick={(): void => this.props.onSelectTab("table")}
+          onClick={(): void => onSelectTab("table")}
         >
           <i className="fas fa-table" />
         </span>
         <span
           className={classNames("QueryResultNav-tabMenu", {
-            "is-selected": this.selectedTab("chart"),
+            "is-selected": selectedTab("chart"),
           })}
-          onClick={(): void => this.props.onSelectTab("chart")}
+          onClick={(): void => onSelectTab("chart")}
         >
           <i className="fas fa-chart-bar" />
         </span>
         <div className="QueryResultNav-share">
-          <span className="QueryResultNav-shareBtn" onClick={(): void => this.setState({ openShareFlyout: true })}>
+          <span className="QueryResultNav-shareBtn" onClick={(): void => setOpenShareFlyout(true)}>
             <i className="fas fa-share-alt" />
           </span>
           <Flyout
-            open={this.state.openShareFlyout}
+            open={openShareFlyout}
             className="QueryResultNav-shareFlyout"
-            onRequestClose={(): void => this.setState({ openShareFlyout: false })}
+            onRequestClose={(): void => setOpenShareFlyout(false)}
           >
             <ul>
-              <li onClick={this.handleClickCopyAsJson}>Copy table as JSON</li>
-              <li onClick={this.handleClickCopyAsTsv}>Copy table as TSV</li>
-              <li onClick={this.handleClickCopyAsCsv}>Copy table as CSV</li>
-              <li onClick={this.handleClickCopyAsMarkdown}>Copy table as Markdown</li>
-              <li onClick={this.handleClickShareOnGist}>Share on gist</li>
-              <li onClick={this.handleClickShareOnBdashServer}>Share on Bdash Server</li>
+              <li onClick={handleClickCopyAsJson}>Copy table as JSON</li>
+              <li onClick={handleClickCopyAsTsv}>Copy table as TSV</li>
+              <li onClick={handleClickCopyAsCsv}>Copy table as CSV</li>
+              <li onClick={handleClickCopyAsMarkdown}>Copy table as Markdown</li>
+              <li onClick={handleClickShareOnGist}>Share on gist</li>
+              <li onClick={handleClickShareOnBdashServer}>Share on Bdash Server</li>
             </ul>
           </Flyout>
         </div>
       </div>
     );
-  }
-}
+  };
+
+  return render();
+});
+
+export default QueryResultNav;

--- a/src/renderer/components/TableList/TableList.tsx
+++ b/src/renderer/components/TableList/TableList.tsx
@@ -9,22 +9,19 @@ type Props = {
   readonly onChangeTableFilter: (dataSource: DataSourceType, value: string) => void;
 };
 
-export default class TableList extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-    this.handleChangeTableFilter = this.handleChangeTableFilter.bind(this);
-  }
+const TableList = React.memo<Props>(function TableList({ dataSource, onSelectTable, onChangeTableFilter }) {
+  if (!dataSource) return null;
 
-  handleClickTable(table: TableType): void {
-    this.props.onSelectTable(this.props.dataSource!, table);
-  }
+  const handleClickTable = (table: TableType): void => {
+    onSelectTable(dataSource, table);
+  };
 
-  handleChangeTableFilter(e: React.ChangeEvent<HTMLInputElement>): void {
+  const handleChangeTableFilter = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const value = e.target.value;
-    this.props.onChangeTableFilter(this.props.dataSource!, value);
-  }
+    onChangeTableFilter(dataSource, value);
+  };
 
-  renderItem(dataSource: DataSourceType, table: TableType, key: number): React.ReactNode {
+  const renderItem = (table: TableType, key: number): React.ReactNode => {
     const { selectedTable, tableFilter } = dataSource;
     const schema = table.schema ? `${table.schema}.` : "";
     const tableName = schema + table.name;
@@ -37,16 +34,13 @@ export default class TableList extends React.Component<Props> {
     });
 
     return (
-      <li className={className} key={key} onClick={(): void => this.handleClickTable(table)}>
+      <li className={className} key={key} onClick={(): void => handleClickTable(table)}>
         <i className="fas fa-table" /> {`${schema}${table.name}`}
       </li>
     );
-  }
+  };
 
-  override render(): React.ReactNode {
-    const dataSource = this.props.dataSource;
-    if (!dataSource) return null;
-
+  const render = (): React.ReactElement | null => {
     if (dataSource.tableFetchingError) {
       return (
         <div className="TableList">
@@ -68,18 +62,20 @@ export default class TableList extends React.Component<Props> {
       );
     }
 
-    const items = (dataSource.tables || []).map((table: TableType, i: number) => {
-      return this.renderItem(dataSource, table, i);
-    });
+    const items = (dataSource.tables || []).map(renderItem);
 
     return (
       <div className="TableList">
         <div className="TableList-filter">
           <i className="fas fa-search" />
-          <input type="search" value={dataSource.tableFilter ?? ""} onChange={this.handleChangeTableFilter} />
+          <input type="search" value={dataSource.tableFilter ?? ""} onChange={handleChangeTableFilter} />
         </div>
         <ul className="TableList-list">{items}</ul>
       </div>
     );
-  }
-}
+  };
+
+  return render();
+});
+
+export default TableList;

--- a/src/renderer/components/TableSummary/TableSummary.tsx
+++ b/src/renderer/components/TableSummary/TableSummary.tsx
@@ -5,31 +5,30 @@ type Props = {
   readonly dataSource?: DataSourceType;
 };
 
-export default class TableSummary extends React.Component<Props> {
-  override render(): React.ReactNode {
-    const dataSource = this.props.dataSource;
-    if (!dataSource || !dataSource.tableSummary) return null;
+const TableSummary = React.memo<Props>(function TableSummary({ dataSource }) {
+  if (!dataSource || !dataSource.tableSummary) return null;
 
-    const tableSummary = dataSource.tableSummary;
-    const heads = tableSummary.defs.fields.map((f, i: number) => <th key={i}>{f}</th>);
-    const rows = tableSummary.defs.rows.map((row, i: number) => {
-      const cols = row.map((v, j: number) => <td key={j}>{v?.toString()}</td>);
-      return <tr key={i}>{cols}</tr>;
-    });
+  const tableSummary = dataSource.tableSummary;
+  const heads = tableSummary.defs.fields.map((f, i: number) => <th key={i}>{f}</th>);
+  const rows = tableSummary.defs.rows.map((row, i: number) => {
+    const cols = row.map((v, j: number) => <td key={j}>{v?.toString()}</td>);
+    return <tr key={i}>{cols}</tr>;
+  });
 
-    const schema = tableSummary.schema ? `${tableSummary.schema}.` : "";
-    const tableName = schema + tableSummary.name;
+  const schema = tableSummary.schema ? `${tableSummary.schema}.` : "";
+  const tableName = schema + tableSummary.name;
 
-    return (
-      <div className="TableSummary">
-        <h1 className="TableSummary-name">{tableName}</h1>
-        <table>
-          <thead>
-            <tr>{heads}</tr>
-          </thead>
-          <tbody>{rows}</tbody>
-        </table>
-      </div>
-    );
-  }
-}
+  return (
+    <div className="TableSummary">
+      <h1 className="TableSummary-name">{tableName}</h1>
+      <table>
+        <thead>
+          <tr>{heads}</tr>
+        </thead>
+        <tbody>{rows}</tbody>
+      </table>
+    </div>
+  );
+});
+
+export default TableSummary;

--- a/src/renderer/pages/DataSource/DataSource.tsx
+++ b/src/renderer/pages/DataSource/DataSource.tsx
@@ -63,7 +63,6 @@ class DataSource extends React.Component<unknown, DataSourceState> {
         <div className="page-DataSource-tableList">
           <TableList
             dataSource={dataSource}
-            {...this.state}
             onSelectTable={Action.selectTable}
             onChangeTableFilter={Action.changeTableFilter}
           />

--- a/src/renderer/pages/Query/Query.tsx
+++ b/src/renderer/pages/Query/Query.tsx
@@ -124,7 +124,6 @@ class Query extends React.Component<unknown, QueryState> {
               Action.updateQuery(query.id, { body, codeMirrorHistory: codeMirrorHistory });
             }}
             onChangeCursorPosition={(line): void => Action.updateEditor({ line })}
-            onChangeEditorHeight={(height): void => Action.updateEditor({ height })}
             onExecute={(): void => {
               this.handleExecute(query);
             }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,6 +3280,11 @@ eslint-plugin-prettier@^4.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz#5f762dfedf8b2cf431c689f533c9d3fa5dcf25ad"
+  integrity sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==
+
 eslint-plugin-react@~7.20.0:
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.20.0.tgz#f98712f0a5e57dfd3e5542ef0604b8739cd47be3"


### PR DESCRIPTION
## Motivation

In order to make it easy to develop and maintain components.

## Target Components
The excluded components from this PR are subject to the following rules:

- it is wrapped by `Container.create()` method (this method does not support functional components)
- it has `componentDidMount()` method (rewriting this method with `useEffect` hook makes it hard to check diffs)
- it has `shouldComponentUpdate()` method (rewriting this method with the second parameter of `React.memo` makes it hard to check diffs)

## Method

### Reduce git diffs by leaving the `render()` function

I tried to reduce git diffs in order to make it easy to review.

Almost components has `render()` function at the last position. 
Usually, functional components returns JSX directly.

```jsx
const MyComponent = () => {
  return <div />
}
```

Rewriting class components' `render()` method to functional components' `render()` function as usual, their indentation will be misaligned. But leaving `render()` function does not cause this problem. If this PR is merged, I will make a PR that remove these `render()` functions.

### Rewriting rules

- Destruct props in order to make it easy to find unused props
- Convert the instance methods that contains HTML elements to `RefObject` by `useRef`, and add `Ref` suffix
- Wrap the functions that is passed to react components by `useCallback` 