### PR TITLE
Feature to update a bdash server query

### DIFF
--- a/src/lib/BdashServerClient.ts
+++ b/src/lib/BdashServerClient.ts
@@ -31,8 +31,12 @@ export default class BdashServerClient {
     return this.generateFullUrl(`/token_validation`);
   }
 
-  getUrl(): string {
+  getCreateUrl(): string {
     return this.generateFullUrl("/create");
+  }
+
+  getUpdateUrl(): string {
+    return this.generateFullUrl("/update");
   }
 
   async validateToken(): Promise<true> {
@@ -59,8 +63,26 @@ export default class BdashServerClient {
   }
 
   async post(contents: any): Promise<BdashServerPostResponse> {
-    const response = await fetch(this.getUrl(), {
+    const response = await fetch(this.getCreateUrl(), {
       method: "POST",
+      headers: this.getHeaders(),
+      body: JSON.stringify(contents),
+    });
+
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+
+    try {
+      return await response.json();
+    } catch (err) {
+      throw new Error("Invalid response.");
+    }
+  }
+
+  async put(contents: any): Promise<BdashServerPostResponse> {
+    const response = await fetch(this.getUpdateUrl(), {
+      method: "PUT",
       headers: this.getHeaders(),
       body: JSON.stringify(contents),
     });

--- a/src/lib/BdashServerClient.ts
+++ b/src/lib/BdashServerClient.ts
@@ -39,6 +39,14 @@ export default class BdashServerClient {
     return this.generateFullUrl("/update");
   }
 
+  getShowUrl(idHash: string): string {
+    if (!this.baseUrl) {
+      throw new Error("BdashServer URL is not set");
+    }
+    const url = new URL(this.baseUrl);
+    return `${url.origin}/query/${idHash}`;
+  }
+
   async validateToken(): Promise<true> {
     if (!this.token || this.token.length === 0) {
       throw new Error("Token is not set");

--- a/src/lib/BdashServerClient.ts
+++ b/src/lib/BdashServerClient.ts
@@ -100,7 +100,7 @@ export default class BdashServerClient {
     }
 
     try {
-      return await response.json();
+      return response.json();
     } catch (err) {
       throw new Error("Invalid response.");
     }

--- a/src/lib/BdashServerClient.ts
+++ b/src/lib/BdashServerClient.ts
@@ -1,3 +1,8 @@
+export type BdashServerPostResponse = {
+  id?: string;
+  html_url: string;
+};
+
 export default class BdashServerClient {
   readonly baseUrl: string | null;
   readonly token: string | null;
@@ -53,7 +58,7 @@ export default class BdashServerClient {
     return true;
   }
 
-  async post(contents: any): Promise<any> {
+  async post(contents: any): Promise<BdashServerPostResponse> {
     const response = await fetch(this.getUrl(), {
       method: "POST",
       headers: this.getHeaders(),

--- a/src/lib/Database/Query.ts
+++ b/src/lib/Database/Query.ts
@@ -18,6 +18,7 @@ export type QueryType = {
   readonly executor?: Base | null;
   readonly runAt?: moment.Moment;
   readonly codeMirrorHistory?: Record<string, unknown> | null; // Edit history of CodeMirror.Doc. https://codemirror.net/doc/manual.html#getHistory
+  readonly bdashServerQueryId?: string;
 };
 
 export type DatabaseQueryType = Omit<QueryType, "fields" | "rows" | "codeMirrorHistory"> & {

--- a/src/lib/Database/schema.ts
+++ b/src/lib/Database/schema.ts
@@ -73,4 +73,8 @@ export const migrations: Migration[] = [
       create index if not exists idx_query_id_on_charts on charts(queryId);
     `,
   },
+  {
+    version: 4,
+    query: `alter table queries add column bdashServerQueryId text`,
+  },
 ];

--- a/src/lib/QuerySharing.ts
+++ b/src/lib/QuerySharing.ts
@@ -9,7 +9,7 @@ import { BdashServerSettingType, GithubSettingType } from "./Setting";
 import { ChartType } from "./Database/Chart";
 import { QueryType } from "./Database/Query";
 import { DataSourceType } from "src/renderer/pages/DataSource/DataSourceStore";
-import BdashServerClient from "./BdashServerClient";
+import BdashServerClient, { BdashServerPostResponse } from "./BdashServerClient";
 
 export default {
   async shareOnGist({
@@ -89,7 +89,7 @@ export default {
     chart: ChartType | undefined;
     setting: BdashServerSettingType;
     dataSource: DataSourceType;
-  }): Promise<void> {
+  }): Promise<BdashServerPostResponse> {
     const chartWidth = 1200;
     const [tsv, svg] = await Promise.all([
       getTableDataAsTsv(query, setting.maximumNumberOfRows),
@@ -117,7 +117,7 @@ export default {
     const client = new BdashServerClient(setting);
     const result = await client.post({ description, files });
 
-    await electron.shell.openExternal(result.html_url);
+    return result;
   },
 };
 

--- a/src/lib/QuerySharing.ts
+++ b/src/lib/QuerySharing.ts
@@ -79,6 +79,18 @@ export default {
     return electron.clipboard.writeText(csv);
   },
 
+  async showSharedQueryOnBdashServer({
+    query,
+    setting,
+  }: {
+    query: QueryType;
+    setting: BdashServerSettingType;
+  }): Promise<void> {
+    if (query.bdashServerQueryId === undefined) return;
+    const url = new BdashServerClient(setting).getShowUrl(query.bdashServerQueryId);
+    return electron.shell.openExternal(url);
+  },
+
   async shareOnBdashServer({
     query,
     chart,

--- a/src/lib/QuerySharing.ts
+++ b/src/lib/QuerySharing.ts
@@ -84,11 +84,15 @@ export default {
     chart,
     setting,
     dataSource,
+    overwrite,
   }: {
     query: QueryType;
     chart: ChartType | undefined;
     setting: BdashServerSettingType;
     dataSource: DataSourceType;
+    overwrite?: {
+      idHash: string;
+    };
   }): Promise<BdashServerPostResponse> {
     const chartWidth = 1200;
     const [tsv, svg] = await Promise.all([
@@ -115,7 +119,12 @@ export default {
     }
 
     const client = new BdashServerClient(setting);
-    const result = await client.post({ description, files });
+    let result: BdashServerPostResponse;
+    if (overwrite === undefined) {
+      result = await client.post({ description, files });
+    } else {
+      result = await client.put({ idHash: overwrite.idHash, description, files });
+    }
 
     return result;
   },

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,4 +1,4 @@
-import electron, { BrowserWindow, dialog, shell } from "electron";
+import electron, { BrowserWindow, dialog, ipcMain, shell } from "electron";
 import path from "path";
 import logger from "./logger";
 
@@ -16,6 +16,27 @@ export async function createWindow(): Promise<void> {
       enableRemoteModule: true,
       contextIsolation: false,
     },
+  });
+
+  ipcMain.on("showUpdateQueryDialog", async (event) => {
+    const { response } = await dialog.showMessageBox(win, {
+      message: "This query has been already shared.",
+      type: "question",
+      buttons: ["Cancel", "Share as a new query", "Update an existing query"],
+      defaultId: 2,
+      cancelId: 0,
+    });
+    switch (response) {
+      case 0:
+        event.returnValue = "cancel";
+        break;
+      case 1:
+        event.returnValue = "create";
+        break;
+      case 2:
+        event.returnValue = "update";
+        break;
+    }
   });
 
   await win.loadURL(`file://${__dirname}/../index.html`);

--- a/src/renderer/components/QueryResult/QueryResult.tsx
+++ b/src/renderer/components/QueryResult/QueryResult.tsx
@@ -14,6 +14,7 @@ type Props = {
   readonly onClickCopyAsMarkdown: () => void;
   readonly onClickShareOnGist: () => void;
   readonly onClickShareOnBdashServer: () => void;
+  readonly onClickShowSharedQueryOnBdashServer: () => void;
   readonly onSelectTab: (tabName: string) => void;
   readonly onUpdateChart: (id: number, params: any) => void;
 };
@@ -27,6 +28,7 @@ const QueryResult: React.FC<Props> = ({
   onClickCopyAsMarkdown,
   onClickShareOnGist,
   onClickShareOnBdashServer,
+  onClickShowSharedQueryOnBdashServer,
   onSelectTab,
   onUpdateChart,
 }) => {
@@ -60,6 +62,7 @@ const QueryResult: React.FC<Props> = ({
         onClickCopyAsMarkdown={onClickCopyAsMarkdown}
         onClickCopyAsTsv={onClickCopyAsTsv}
         onClickShareOnBdashServer={onClickShareOnBdashServer}
+        onClickShowSharedQueryOnBdashServer={onClickShowSharedQueryOnBdashServer}
         onClickShareOnGist={onClickShareOnGist}
         onSelectTab={onSelectTab}
       />

--- a/src/renderer/components/QueryResultNav/QueryResultNav.tsx
+++ b/src/renderer/components/QueryResultNav/QueryResultNav.tsx
@@ -11,6 +11,7 @@ type Props = {
   readonly onClickCopyAsMarkdown: () => void;
   readonly onClickShareOnGist: () => void;
   readonly onClickShareOnBdashServer: () => void;
+  readonly onClickShowSharedQueryOnBdashServer: () => void;
   readonly onSelectTab: (tabName: "table" | "chart") => void;
 };
 
@@ -22,6 +23,7 @@ const QueryResultNav = React.memo<Props>(function QueryResultNav({
   onClickCopyAsMarkdown,
   onClickShareOnGist,
   onClickShareOnBdashServer,
+  onClickShowSharedQueryOnBdashServer,
   onSelectTab,
 }) {
   const [openShareFlyout, setOpenShareFlyout] = React.useState(false);
@@ -60,6 +62,11 @@ const QueryResultNav = React.memo<Props>(function QueryResultNav({
     onClickShareOnBdashServer();
   };
 
+  const handleClickShowSharedQueryOnBdashServer = (): void => {
+    setOpenShareFlyout(false);
+    onClickShowSharedQueryOnBdashServer();
+  };
+
   return (
     <div className="QueryResultNav">
       <span
@@ -79,6 +86,15 @@ const QueryResultNav = React.memo<Props>(function QueryResultNav({
         <i className="fas fa-chart-bar" />
       </span>
       <div className="QueryResultNav-share">
+        {query.bdashServerQueryId && (
+          <span
+            className="QueryResultNav-shareBtn"
+            title="Open in Bdash Server"
+            onClick={handleClickShowSharedQueryOnBdashServer}
+          >
+            <i className="fas fa-globe"></i>
+          </span>
+        )}
         <span className="QueryResultNav-shareBtn" onClick={(): void => setOpenShareFlyout(true)}>
           <i className="fas fa-share-alt" />
         </span>

--- a/src/renderer/pages/Query/Query.tsx
+++ b/src/renderer/pages/Query/Query.tsx
@@ -93,7 +93,13 @@ class Query extends React.Component<unknown, QueryState> {
     }
 
     try {
-      const { id: bdashServerQueryId, html_url } = await QuerySharing.shareOnBdashServer({ query, chart, setting, dataSource, overwrite });
+      const { id: bdashServerQueryId, html_url } = await QuerySharing.shareOnBdashServer({
+        query,
+        chart,
+        setting,
+        dataSource,
+        overwrite,
+      });
       await electron.shell.openExternal(html_url);
       if (bdashServerQueryId) {
         await Action.updateQuery(query.id, { bdashServerQueryId });
@@ -101,6 +107,10 @@ class Query extends React.Component<unknown, QueryState> {
     } catch (err) {
       alert(err.message);
     }
+  }
+
+  async handleShowSharedQueryOnBdashServer(query: QueryType): Promise<void> {
+    return QuerySharing.showSharedQueryOnBdashServer({ query, setting: this.state.setting.bdashServer });
   }
 
   renderMain(): React.ReactNode {
@@ -163,6 +173,9 @@ class Query extends React.Component<unknown, QueryState> {
             }}
             onClickShareOnBdashServer={(): void => {
               this.handleShareOnBdashServer(query);
+            }}
+            onClickShowSharedQueryOnBdashServer={(): void => {
+              this.handleShowSharedQueryOnBdashServer(query);
             }}
             onSelectTab={(name): void => {
               Action.selectResultTab(query, name);

--- a/src/renderer/pages/Query/Query.tsx
+++ b/src/renderer/pages/Query/Query.tsx
@@ -83,7 +83,7 @@ class Query extends React.Component<unknown, QueryState> {
       return;
     }
 
-    let overwrite: { idHash: string } | undefined = undefined;
+    let overwrite: { idHash: string } | undefined;
     if (query.bdashServerQueryId) {
       const response = electron.ipcRenderer.sendSync("showUpdateQueryDialog");
       if (response === "cancel") return;

--- a/src/renderer/pages/Query/Query.tsx
+++ b/src/renderer/pages/Query/Query.tsx
@@ -1,3 +1,4 @@
+import electron from "electron";
 import React from "react";
 import SplitterLayout from "react-splitter-layout";
 import QuerySharing from "../../../lib/QuerySharing";
@@ -83,7 +84,9 @@ class Query extends React.Component<unknown, QueryState> {
     }
 
     try {
-      await QuerySharing.shareOnBdashServer({ query, chart, setting, dataSource });
+      const { id: bdashServerQueryId, html_url } = await QuerySharing.shareOnBdashServer({ query, chart, setting, dataSource });
+      await electron.shell.openExternal(html_url);
+      await Action.updateQuery(query.id, { bdashServerQueryId });
     } catch (err) {
       alert(err.message);
     }

--- a/src/renderer/pages/Query/Query.tsx
+++ b/src/renderer/pages/Query/Query.tsx
@@ -83,10 +83,21 @@ class Query extends React.Component<unknown, QueryState> {
       return;
     }
 
+    let overwrite: { idHash: string } | undefined = undefined;
+    if (query.bdashServerQueryId) {
+      const response = electron.ipcRenderer.sendSync("showUpdateQueryDialog");
+      if (response === "cancel") return;
+      if (response === "update") {
+        overwrite = { idHash: query.bdashServerQueryId };
+      }
+    }
+
     try {
-      const { id: bdashServerQueryId, html_url } = await QuerySharing.shareOnBdashServer({ query, chart, setting, dataSource });
+      const { id: bdashServerQueryId, html_url } = await QuerySharing.shareOnBdashServer({ query, chart, setting, dataSource, overwrite });
       await electron.shell.openExternal(html_url);
-      await Action.updateQuery(query.id, { bdashServerQueryId });
+      if (bdashServerQueryId) {
+        await Action.updateQuery(query.id, { bdashServerQueryId });
+      }
     } catch (err) {
       alert(err.message);
     }

--- a/src/renderer/pages/Query/QueryAction.ts
+++ b/src/renderer/pages/Query/QueryAction.ts
@@ -59,7 +59,7 @@ const QueryAction = {
     dispatch("addNewQuery", { query });
   },
 
-  async updateQuery(id: number, params: Partial<QueryType>): Promise<void> {
+  updateQuery(id: number, params: Partial<QueryType>): Promise<void> {
     dispatch("updateQuery", { id, params });
     return Database.Query.update(id, {
       ...params,

--- a/src/renderer/pages/Query/QueryAction.ts
+++ b/src/renderer/pages/Query/QueryAction.ts
@@ -59,7 +59,7 @@ const QueryAction = {
     dispatch("addNewQuery", { query });
   },
 
-  updateQuery(id: number, params: Partial<QueryType>): Promise<void> {
+  async updateQuery(id: number, params: Partial<QueryType>): Promise<void> {
     dispatch("updateQuery", { id, params });
     return Database.Query.update(id, {
       ...params,

--- a/test/unit/lib/Database/Query.test.ts
+++ b/test/unit/lib/Database/Query.test.ts
@@ -47,6 +47,7 @@ suite("Database/Query", () => {
       updatedAt: "2017-01-02 00:00:00",
       createdAt: "2017-01-01 00:00:00",
       codeMirrorHistory: null,
+      bdashServerQueryId: null,
     });
   });
 


### PR DESCRIPTION
https://github.com/bdash-app/bdash-server/issues/13 の対応で、Bdash Server にクエリをシェアした時にクエリ ID を DB に保存しておいて、再度シェアする際に上書きするか新規クエリとしてシェアするかを選択できるようにしました。
またシェア済みのクエリはシェアボタンの横に Bdash Server で開くボタンを表示するようにしました。

<img width="338" alt="スクリーンショット 2022-07-14 13 10 48" src="https://user-images.githubusercontent.com/1413408/178898705-a62186c6-d34b-4ce4-a5dd-4491ec182201.png">

![](https://user-images.githubusercontent.com/1413408/178898684-baf48c91-df7c-4f6b-8edb-0d63bec69350.png)

