### PR TITLE
Add AppErrorBoundary component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 *.sqlite3
-tmp/
-dist/
-app/
+/tmp
+/dist
+/app
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,7 @@
-node_modules/
-out/
-app/
-dist/
-tmp/
+/node_modules
+/out
+/app
+/dist
+/tmp
 package.json
 package-lock.json

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -6,10 +6,16 @@ import ReactDOM from "react-dom";
 import Bdash from "../lib/Bdash";
 import "./components/SplashScreen";
 import App from "./pages/App";
+import AppErrorBoundary from "./pages/App/AppErrorBoundary";
 
 Bdash.initialize()
   .then(() => {
-    ReactDOM.render(<App />, document.getElementById("app"));
+    ReactDOM.render(
+      <AppErrorBoundary>
+        <App />
+      </AppErrorBoundary>,
+      document.getElementById("app")
+    );
   })
   .catch((err: Error) => {
     // TODO: process exit after close alert

--- a/src/renderer/pages/App/App.tsx
+++ b/src/renderer/pages/App/App.tsx
@@ -37,7 +37,7 @@ class App extends React.Component<unknown, AppState> {
         <div className="page-app-main">
           <Page />
         </div>
-      </div >
+      </div>
     );
   }
 }

--- a/src/renderer/pages/App/App.tsx
+++ b/src/renderer/pages/App/App.tsx
@@ -13,12 +13,6 @@ class App extends React.Component<unknown, AppState> {
     Action.initialize();
   }
 
-  override componentDidCatch(error, info) {
-    console.error(error);
-    console.error(info);
-    window.alert("An unexpected error has occurred 🥲")
-  }
-
   getSelectedPage(): typeof Query | typeof DataSource | typeof Setting {
     switch (this.state.selectedPage) {
       case "query":

--- a/src/renderer/pages/App/AppAction.ts
+++ b/src/renderer/pages/App/AppAction.ts
@@ -14,7 +14,7 @@ const AppAction = {
 
   selectPage(page: string): void {
     dispatch("selectPage", { page });
-  }
+  },
 };
 
 export default AppAction;

--- a/src/renderer/pages/App/AppErrorBoundary.tsx
+++ b/src/renderer/pages/App/AppErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+type Props = Readonly<unknown>;
+
+interface State {
+  hasError: boolean;
+}
+
+export default class AppErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  override componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error(error);
+    console.error(info);
+    window.alert("An unexpected error has occurred 🥲");
+  }
+
+  override render(): React.ReactNode {
+    if (this.state.hasError) {
+      return <h1>An unexpected error has occurred 🥲</h1>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/renderer/pages/App/AppStore.ts
+++ b/src/renderer/pages/App/AppStore.ts
@@ -8,7 +8,7 @@ export default class AppStore extends Store<AppState> {
   constructor() {
     super();
     this.state = {
-      selectedPage: "query"
+      selectedPage: "query",
     };
   }
 


### PR DESCRIPTION
`App` コンポーネントを関数コンポーネントに書き換えるにあたり、エラーハンドリングの実装のみ `AppErrorBoundary` コンポーネントへ移動しました。
また、 `.gitignore` と `.prettierignore` が既存の設定だと `src/renderer/pages/App` ディレクトリを無視していたので、ルートディレクトリのみ対象とするように変更しました。
レビューお願いします。