### PR TITLE
[TreasureData] fix: TreasureData data source failed with empty result

### DIFF
--- a/src/lib/DataSourceDefinition/TreasureData.ts
+++ b/src/lib/DataSourceDefinition/TreasureData.ts
@@ -148,7 +148,13 @@ export default class TreasureData extends Base {
 
       switch (status) {
         case "success": {
+          const fields = JSON.parse(result.hive_result_schema).map((f) => f[0]);
           const rowsString = await jobResult();
+          if (typeof rowsString === "object") {
+            // rowsString is an object when rows are empty.
+            const emptyRows = [] as string[];
+            return { fields, emptyRows, status };
+          }
           const rows = rowsString
             .trim()
             .split("\n")
@@ -157,7 +163,6 @@ export default class TreasureData extends Base {
                 return v === null || typeof v !== "object" ? v : JSON.stringify(v);
               });
             });
-          const fields = JSON.parse(result.hive_result_schema).map((f) => f[0]);
           return { fields, rows, status };
         }
         case "error": {


### PR DESCRIPTION
Treasure Data data source has failed with empty rows like this:

<img width="414" alt="スクリーンショット 2022-09-26 12 23 47" src="https://user-images.githubusercontent.com/1703556/192187838-0650f848-81fb-41ab-9429-3a9166fa9d87.png">

After this patch, bdash shows same result as:

<img width="535" alt="スクリーンショット 2022-09-26 12 25 01" src="https://user-images.githubusercontent.com/1703556/192187957-baadc14a-9bcf-40ae-8d6b-21bebe7b5a8a.png">
