### PR TITLE
Load a query from DB whenever select or duplicate it

### DIFF
--- a/src/renderer/components/QueryList/QueryList.tsx
+++ b/src/renderer/components/QueryList/QueryList.tsx
@@ -7,8 +7,8 @@ type Props = {
   readonly queries: QueryType[];
   readonly selectedQueryId: number | null;
   readonly onAddQuery: () => void;
-  readonly onSelectQuery: (query: QueryType) => void;
-  readonly onDuplicateQuery: (query: QueryType) => void;
+  readonly onSelectQuery: (queryId: number) => void;
+  readonly onDuplicateQuery: (queryId: number) => void;
   readonly onDeleteQuery: (queryId: number) => void;
 };
 
@@ -24,21 +24,21 @@ const QueryList: React.FC<Props> = ({
 
   const handleClickItem = onSelectQuery;
 
-  const handleContextMenu = (query: QueryType): void => {
-    onSelectQuery(query);
+  const handleContextMenu = (queryId: number): void => {
+    onSelectQuery(queryId);
     setImmediate(() => {
       const menu = remote.Menu.buildFromTemplate([
         {
           label: "Duplicate",
           click: (): void => {
-            onDuplicateQuery(query);
+            onDuplicateQuery(queryId);
           },
         },
         {
           label: "Delete",
           click: (): void => {
             if (window.confirm("Are you sure?")) {
-              onDeleteQuery(query.id);
+              onDeleteQuery(queryId);
             }
           },
         },
@@ -68,8 +68,8 @@ const QueryList: React.FC<Props> = ({
           <li
             key={query.id}
             className={selectedQueryId === query.id ? "is-selected" : ""}
-            onClick={(): void => handleClickItem(query)}
-            onContextMenu={(): void => handleContextMenu(query)}
+            onClick={(): void => handleClickItem(query.id)}
+            onContextMenu={(): void => handleContextMenu(query.id)}
           >
             <div className="QueryList-item">
               <div className="QueryList-item-title">{query.title}</div>

--- a/src/renderer/pages/Query/QueryAction.ts
+++ b/src/renderer/pages/Query/QueryAction.ts
@@ -44,14 +44,9 @@ const QueryAction = {
     );
   },
 
-  async selectQuery(query: QueryType): Promise<void> {
-    const id = query.id;
-    if (query.body === undefined) {
-      const query = await Database.Query.find(id);
-      dispatch("selectQuery", { id, query });
-    } else {
-      dispatch("selectQuery", { id, query: {} });
-    }
+  async selectQuery(id: number): Promise<void> {
+    const query = await Database.Query.find(id);
+    dispatch("selectQuery", { id, query });
   },
 
   async addNewQuery({ dataSourceId }): Promise<void> {
@@ -67,7 +62,8 @@ const QueryAction = {
     });
   },
 
-  async duplicateQuery(query: QueryType): Promise<void> {
+  async duplicateQuery(id: number): Promise<void> {
+    const query = await Database.Query.find(id);
     const newQuery = await Database.Query.create(query.title, query.dataSourceId, query.body);
     dispatch("addNewQuery", { query: newQuery });
   },


### PR DESCRIPTION
## Problem
https://github.com/bdash-app/bdash/pull/256 makes a bug. No data source is selected when user select a query from the list because of it.

## Reason

That makes it get not only `id` and `title` but also **`body`** and `created_at` for showing the query list.
https://github.com/bdash-app/bdash/blob/b64eb494729b99454d671d4eec4d3234928ce1aa/src/lib/Database/Query.ts#L33-L34

But `selectQuery` does not refetch a query from DB when `body` is not empty. Therefore the properties of the selected query other than the above properties (id, title, body, created_at) does not appear in the query details screen.

https://github.com/bdash-app/bdash/blob/b64eb494729b99454d671d4eec4d3234928ce1aa/src/renderer/pages/Query/QueryAction.ts#L47-L55

## Solution

Always refetch a query from DB when a user make actions (select, duplicate) on the query.