### PR TITLE
Use volta to fix node and yarn versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,9 @@
     "@types/react": "16.8.25",
     "@types/react-dom": "16.8.5"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "volta": {
+    "node": "14.21.3",
+    "yarn": "1.22.19"
+  }
 }


### PR DESCRIPTION
https://volta.sh

I added `volta` option into package.json to fix node and yarn versions by following these codes.

## Node.js v14
https://github.com/bdash-app/bdash/blob/b3d9db5f987557cc2d214c3e8ba18b2c2c17d6b1/.github/workflows/prepare_release.yml#L22
https://github.com/bdash-app/bdash/blob/b3d9db5f987557cc2d214c3e8ba18b2c2c17d6b1/.github/workflows/test.yml#L24


## Yarn v1

https://github.com/bdash-app/bdash/blob/b3d9db5f987557cc2d214c3e8ba18b2c2c17d6b1/yarn.lock#L2

