### PR TITLE
Revert "Use universal binary for macOS"

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -32,12 +32,9 @@ win:
     - nsis
 
 mac:
-  singleArchFiles: "*"
   target:
-    - target: dmg
-      arch: universal
-    - target: zip
-      arch: universal
+    - zip
+    - dmg
   category: public.app-category.developer-tools
   hardenedRuntime: true
   entitlements: ./build/entitlement.plist

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -7,7 +7,7 @@ module.exports = async function () {
     return;
   }
 
-  const appPath = path.resolve(__dirname, "../dist/production/mac-universal/Bdash.app");
+  const appPath = path.resolve(__dirname, "../dist/production/mac/Bdash.app");
 
   if (!fs.existsSync(appPath)) {
     throw new Error(`Cannot find application at: ${appPath}`);
@@ -16,12 +16,11 @@ module.exports = async function () {
   console.log("afterSign: Notarizing");
 
   await notarize({
-    tool: "notarytool",
     appBundleId: "io.bdash",
     appPath: appPath,
     appleId: process.env.APPLE_ID,
     appleIdPassword: process.env.APPLE_PASSWORD,
-    teamId: process.env.ASC_PROVIDER,
+    ascProvider: process.env.ASC_PROVIDER,
   });
 
   console.log("afterSign: Notarized");


### PR DESCRIPTION
Reverts bdash-app/bdash#272

It has been crashed. I will revert it...

<img width="425" alt="スクリーンショット 2024-06-14 12 46 56" src="https://github.com/bdash-app/bdash/assets/1413408/7a3d8cba-572d-4ddd-8897-fd27121fa1c3">
