### PR TITLE
Add desktop notification for query completion when app is in background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 /dist
 /app
 .DS_Store
+
+.claude/settings.local.json
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Bdash is an Electron-based SQL client for lightweight data analysis. It's a desktop application built with TypeScript, React, and Electron that supports multiple database types including MySQL, PostgreSQL, SQLite3, BigQuery, Treasure Data, and Amazon Athena.
+
+## Key Architecture
+
+### Structure
+- **Main process**: `src/main/` - Electron main process handling window management, menus, updates
+- **Renderer process**: `src/renderer/` - React-based UI with components and pages
+- **Shared libraries**: `src/lib/` - Business logic including database clients and data models
+- **Database layer**: `src/lib/Database/` - Data persistence using SQLite with models for DataSource, Query, Chart, Connection
+
+### Key Components
+- **DataSource system**: `src/lib/DataSourceDefinition/` - Pluggable database adapters for different database types
+- **Flux architecture**: `src/renderer/flux/` - State management with Store/Action pattern
+- **Page structure**: `src/renderer/pages/` - Main app sections (App, DataSource, Query, Setting) each with their own stores and actions
+
+## Development Commands
+
+### Basic Development
+```bash
+yarn install          # Install dependencies
+yarn watch            # Build and watch for changes (webpack)
+yarn start            # Start Electron app
+```
+
+### Testing
+```bash
+yarn test             # Run all tests (unit + integration)
+yarn test:unit        # Run unit tests only
+yarn test:unit:remote # Run remote-dependent unit tests
+yarn test:integration # Run integration tests (builds app first)
+```
+
+### Linting and Code Quality
+```bash
+yarn lint             # Run all linting (ESLint + TypeScript + Prettier)
+yarn lint:eslint      # ESLint only
+yarn lint:tsc         # TypeScript type checking only
+yarn lint:prettier    # Prettier formatting check only
+yarn format           # Auto-format code with Prettier
+yarn ci               # Run linting + unit tests (CI pipeline)
+```
+
+### Building and Release
+```bash
+yarn build            # Build for development
+yarn release:prepare  # Build for production and package with electron-builder
+```
+
+## Database Models and Schema
+
+The application uses SQLite for local data storage with these main models:
+- **DataSource**: Database connection configurations
+- **Query**: Saved SQL queries with metadata
+- **Chart**: Visualization configurations for query results
+- **Connection**: Runtime database connections
+
+## Testing Structure
+
+- **Unit tests**: `test/unit/` - Component and library tests using Mocha + TDD interface
+- **Integration tests**: `test/integration/` - End-to-end tests using Spectron
+- **Test fixtures**: `test/fixtures/` - Database setup for different database types
+- **Test helpers**: `test/helpers/` - Shared testing utilities
+
+## Build Configuration
+
+- Uses Webpack with separate configs for main and renderer processes
+- TypeScript compilation with strict settings enabled
+- CSS extraction and asset handling for fonts/images
+- Electron Builder for packaging with notarization support

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,4 +1,4 @@
-import electron, { BrowserWindow, dialog, ipcMain, shell } from "electron";
+import electron, { BrowserWindow, dialog, ipcMain, shell, Notification } from "electron";
 import path from "path";
 import logger from "./logger";
 import Config from "./Config";
@@ -19,6 +19,31 @@ export async function createWindow(): Promise<void> {
   });
 
   ipcMain.handle("getConfig", async () => Config);
+
+  ipcMain.on("queryCompleted", (_event, data) => {
+    const { success, title, runtime, rowCount, errorMessage } = data;
+
+    if (!win.isFocused()) {
+      const notificationTitle = success ? "Query completed" : "Query failed";
+      let notificationBody;
+
+      if (success) {
+        const timeText = runtime ? ` in ${runtime}ms` : "";
+        const rowText = rowCount !== undefined ? ` (${rowCount} rows)` : "";
+        notificationBody = `"${title}" completed${timeText}${rowText}`;
+      } else {
+        const errorText = errorMessage
+          ? `: ${errorMessage.substring(0, 100)}${errorMessage.length > 100 ? "..." : ""}`
+          : "";
+        notificationBody = `"${title}" failed${errorText}`;
+      }
+
+      new Notification({
+        title: notificationTitle,
+        body: notificationBody,
+      }).show();
+    }
+  });
 
   ipcMain.on("showUpdateQueryDialog", async (event) => {
     const { response } = await dialog.showMessageBox(win, {

--- a/src/renderer/pages/Query/QueryAction.ts
+++ b/src/renderer/pages/Query/QueryAction.ts
@@ -1,4 +1,5 @@
 import moment from "moment";
+import { ipcRenderer } from "electron";
 import { dispatch } from "./QueryStore";
 import { setting } from "../../../lib/Setting";
 import Database from "../../../lib/Database";
@@ -104,6 +105,13 @@ const QueryAction = {
         params: Object.assign({ executor: null }, params),
       });
       Database.Query.update(id, params);
+
+      ipcRenderer.send("queryCompleted", {
+        success: false,
+        title: query.title,
+        errorMessage: err.message,
+      });
+
       return;
     }
 
@@ -127,6 +135,13 @@ const QueryAction = {
         runAt: params.runAt?.utc().format("YYYY-MM-DD HH:mm:ss"),
       })
     );
+
+    ipcRenderer.send("queryCompleted", {
+      success: true,
+      title: query.title,
+      runtime: params.runtime,
+      rowCount: result.rows?.length || 0,
+    });
   },
 
   async cancelQuery(query: QueryType): Promise<void> {


### PR DESCRIPTION
## Summary
- Adds desktop notifications when query execution completes (both success and failure)
- Only shows notifications when the application window is not focused (in background)
- Includes relevant execution details: runtime and row count for successful queries, error messages for failed queries

## Implementation
- Added IPC communication between renderer and main process when queries complete
- Used Electron's built-in Notification API for cross-platform desktop notifications  
- Implemented window focus detection to avoid showing notifications when app is active

## Test plan
- [ ] Run a query while app is focused - should not show notification
- [ ] Run a query while app is in background - should show appropriate notification
- [ ] Test both successful and failed query scenarios
- [ ] Verify notification content includes expected details (runtime, row count, error messages)

🤖 Generated with [Claude Code](https://claude.ai/code)