### PR TITLE
Fix clickable elements in drag regions on macOS

### DIFF
--- a/src/renderer/components/DataSourceList/DataSourceList.css
+++ b/src/renderer/components/DataSourceList/DataSourceList.css
@@ -16,6 +16,7 @@
 
 .DataSourceList-new i {
   cursor: pointer;
+  -webkit-app-region: no-drag;
 }
 
 .DataSourceList > ul {

--- a/src/renderer/components/GlobalMenu/GlobalMenu.css
+++ b/src/renderer/components/GlobalMenu/GlobalMenu.css
@@ -12,6 +12,7 @@
   font-size: 28px;
   cursor: pointer;
   height: 42px;
+  -webkit-app-region: no-drag;
 }
 
 .GlobalMenu-item:hover {

--- a/src/renderer/components/QueryList/QueryList.css
+++ b/src/renderer/components/QueryList/QueryList.css
@@ -19,6 +19,7 @@
 
 .QueryList-new i {
   cursor: pointer;
+  -webkit-app-region: no-drag;
 }
 
 .QueryList-new .QueryList-filter {
@@ -26,6 +27,7 @@
   position: sticky;
   top: 0;
   background-color: inherit;
+  -webkit-app-region: no-drag;
 }
 
 .QueryList-new .QueryList-filter > i {


### PR DESCRIPTION
## Summary
- Fixes click event blocking issues on QueryList, DataSourceList, and GlobalMenu components on macOS
- Adds `-webkit-app-region: no-drag` to clickable elements within areas that have `-webkit-app-region: drag`
- Resolves issue where elements with `darwin` class were not responding to click events

## Test plan
- [x] Verify QueryList "+" button clicks work on macOS
- [x] Verify QueryList filter input works on macOS  
- [x] Verify GlobalMenu items are clickable on macOS
- [x] Verify DataSourceList "+" button clicks work on macOS
- [x] Test on both macOS and other platforms to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)