### PR TITLE
Add notify setting

### DIFF
--- a/src/lib/Setting.ts
+++ b/src/lib/Setting.ts
@@ -16,6 +16,7 @@ export type SettingType = {
   readonly bdashServer: BdashServerSettingType;
   readonly experimentalFeature: ExperimentalFeatureSettingType;
   readonly defaultDataSourceId: number | null;
+  readonly notification: NotificationSettingType;
 };
 
 export type FormatterSettingType = {
@@ -37,6 +38,14 @@ export type BdashServerSettingType = {
 
 export type ExperimentalFeatureSettingType = {
   autoCompleteEnabled: boolean;
+};
+
+export const notificationWhenOptions = ["focusing", "not_focusing", "always"] as const;
+export type NotificationWhenType = typeof notificationWhenOptions[number];
+
+export type NotificationSettingType = {
+  enabled: boolean;
+  when: NotificationWhenType;
 };
 
 // type for partial updating parameter.
@@ -66,6 +75,10 @@ export default class Setting {
         autoCompleteEnabled: false,
       },
       defaultDataSourceId: null,
+      notification: {
+        enabled: true,
+        when: "not_focusing",
+      },
     };
   }
 

--- a/src/renderer/pages/Query/QueryAction.ts
+++ b/src/renderer/pages/Query/QueryAction.ts
@@ -86,6 +86,7 @@ const QueryAction = {
     const { query: queryBody, startLine } = await Util.findQueryByLine(query.body, dataSource.mimeType, line);
     const executor = DataSource.create(dataSource);
     const id = query.id;
+    const _setting = setting.load();
     dispatch("updateQuery", { id, params: { status: "working", executor } });
 
     const start = Date.now();
@@ -110,6 +111,7 @@ const QueryAction = {
         success: false,
         title: query.title,
         errorMessage: err.message,
+        _setting,
       });
 
       return;
@@ -141,6 +143,7 @@ const QueryAction = {
       title: query.title,
       runtime: params.runtime,
       rowCount: result.rows?.length || 0,
+      _setting,
     });
   },
 

--- a/src/renderer/pages/Setting/Setting.tsx
+++ b/src/renderer/pages/Setting/Setting.tsx
@@ -6,7 +6,7 @@ import Action from "./SettingAction";
 import Button from "../../components/Button";
 import ProgressIcon from "../../components/ProgressIcon";
 import { selectStyles } from "../../components/Select";
-import { indentValues } from "../../../lib/Setting";
+import { indentValues, notificationWhenOptions } from "../../../lib/Setting";
 
 class Setting extends React.Component<unknown, SettingState> {
   override componentDidMount(): void {
@@ -171,6 +171,28 @@ class Setting extends React.Component<unknown, SettingState> {
               min={0}
               value={bdashServer.maximumNumberOfRows}
               onChange={(e): void => Action.update({ bdashServer: { maximumNumberOfRows: Number(e.target.value) } })}
+            />
+          </div>
+        </div>
+        <div className="page-Setting-section1">
+          <h1>Notification</h1>
+          <div className="page-Setting-section2">
+            <h2>Enable</h2>
+            <input
+              type="checkbox"
+              onChange={(e): void => Action.update({ notification: { enabled: e.target.checked } })}
+              checked={setting.notification.enabled}
+            />
+          </div>
+          <div className="page-Setting-section2">
+            <h2>Notify when</h2>
+            <Select
+              value={{ value: setting.notification.when, label: setting.notification.when }}
+              options={notificationWhenOptions.map((v) => ({ value: v, label: v }))}
+              onChange={(e): void => Action.update({ notification: { when: (e as OptionTypeBase).value } })}
+              isClearable={false}
+              isSearchable={false}
+              styles={selectStyles}
             />
           </div>
         </div>


### PR DESCRIPTION
# Summary

- Add a notification setting for controlling:
  - enable / disable notification
  - what condition the notification will be send.

About the condition for sending notifications, I prepared following:
- `focusing`:  Send notification when the bdash window is focused.
- `not focusing`: Opposite of `focusing`. Send notification when the bdash window is **NOT** focused (default).
- `always`: Send notification regardless of focusing
