### PR TITLE
Support AWS profile for Athena/Timestream

### DIFF
--- a/src/lib/AthenaClient.ts
+++ b/src/lib/AthenaClient.ts
@@ -3,6 +3,7 @@ import retry from "./Util/retry";
 
 interface AthenaClientConfig {
   region: string;
+  profile?: string;
   accessKeyId?: string;
   secretAccessKey?: string;
   database: string;
@@ -17,10 +18,14 @@ export default class AthenaClient {
   executionId: string;
 
   constructor(config: AthenaClientConfig) {
-    const { region, accessKeyId, secretAccessKey } = config;
+    const { region, profile, accessKeyId, secretAccessKey } = config;
     this.config = config;
 
     const clientConfig: any = { region };
+
+    if (profile) {
+      clientConfig.profile = profile;
+    }
 
     // Only add credentials if BOTH accessKeyId and secretAccessKey are provided.
     if (accessKeyId && secretAccessKey) {

--- a/src/lib/DataSourceDefinition/Athena.ts
+++ b/src/lib/DataSourceDefinition/Athena.ts
@@ -21,6 +21,12 @@ export default class Athena extends Base {
         required: true,
       },
       {
+        name: "profile",
+        label: "Profile",
+        type: "string",
+        placeholder: "Optional - uses AWS default profile if empty",
+      },
+      {
         name: "accessKeyId",
         label: "Access key ID",
         type: "string",

--- a/src/lib/DataSourceDefinition/Timestream.ts
+++ b/src/lib/DataSourceDefinition/Timestream.ts
@@ -25,6 +25,12 @@ export default class Timestream extends Base {
         required: true,
       },
       {
+        name: "profile",
+        label: "Profile",
+        type: "string",
+        placeholder: "Optional - uses AWS default profile if empty",
+      },
+      {
         name: "accessKeyId",
         label: "Access key ID",
         type: "string",
@@ -49,6 +55,10 @@ export default class Timestream extends Base {
     super(config);
 
     const clientConfig: any = { region: config.region };
+
+    if (config.profile) {
+      clientConfig.profile = config.profile;
+    }
 
     // Only add credentials if BOTH accessKeyId and secretAccessKey are provided.
     if (config.accessKeyId && config.secretAccessKey) {


### PR DESCRIPTION
The underlying motivation is the same as with #302: to avoid using static credentials. There is a configuration option called `credential_process` in ~/.aws/config, which allows you to delegate the retrieval of credentials to an external command specified here. https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html A specific use case for this is Mairu.
https://github.com/sorah/mairu?tab=readme-ov-file#3-use-as-a-credential-process-provider