### PR TITLE
Use native title bar on macOS

### DIFF
--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -58,7 +58,6 @@ export async function createWindow(): Promise<void> {
     width: 1280,
     height: 780,
     title: "Bdash",
-    titleBarStyle: process.platform === "darwin" ? "hidden" : undefined,
     icon: path.join(__dirname, "..", "icon.png"),
     webPreferences: {
       nodeIntegration: true,

--- a/src/renderer/components/DataSourceList/DataSourceList.css
+++ b/src/renderer/components/DataSourceList/DataSourceList.css
@@ -10,13 +10,8 @@
   border-bottom: 1px solid var(--color-border);
 }
 
-.DataSourceList-new.darwin {
-  -webkit-app-region: drag;
-}
-
 .DataSourceList-new i {
   cursor: pointer;
-  -webkit-app-region: no-drag;
 }
 
 .DataSourceList > ul {

--- a/src/renderer/components/DataSourceList/DataSourceList.tsx
+++ b/src/renderer/components/DataSourceList/DataSourceList.tsx
@@ -108,7 +108,7 @@ const DataSourceList: React.FC<Props> = ({
 
   return (
     <div className="DataSourceList">
-      <div className={classNames("DataSourceList-new", { darwin: process.platform === "darwin" })}>
+      <div className="DataSourceList-new">
         <i className="fas fa-plus" onClick={onClickNew} />
       </div>
       <Menu id={MENU_ID}>

--- a/src/renderer/components/GlobalMenu/GlobalMenu.css
+++ b/src/renderer/components/GlobalMenu/GlobalMenu.css
@@ -1,5 +1,4 @@
 .GlobalMenu {
-  padding-top: 32px;
   height: 100vh;
   background-color: var(--color-menu-bg);
 }
@@ -12,7 +11,6 @@
   font-size: 28px;
   cursor: pointer;
   height: 42px;
-  -webkit-app-region: no-drag;
 }
 
 .GlobalMenu-item:hover {

--- a/src/renderer/components/QueryList/QueryList.css
+++ b/src/renderer/components/QueryList/QueryList.css
@@ -4,10 +4,6 @@
   height: 100vh;
 }
 
-.QueryList-new.darwin {
-  -webkit-app-region: drag;
-}
-
 .QueryList-new {
   display: flex;
   justify-content: space-between;
@@ -25,7 +21,6 @@
 
 .QueryList-new i {
   cursor: pointer;
-  -webkit-app-region: no-drag;
 }
 
 .QueryList-new .QueryList-filter {
@@ -33,7 +28,6 @@
   position: sticky;
   top: 0;
   background-color: inherit;
-  -webkit-app-region: no-drag;
 }
 
 .QueryList-new .QueryList-filter > i {

--- a/src/renderer/components/QueryList/QueryList.tsx
+++ b/src/renderer/components/QueryList/QueryList.tsx
@@ -1,5 +1,4 @@
 import React, { useState, MouseEvent } from "react";
-import classNames from "classnames";
 import { QueryType } from "../../../lib/Database/Query";
 import { Menu, Item, useContextMenu } from "react-contexify";
 import "react-contexify/ReactContexify.css";
@@ -70,7 +69,7 @@ const QueryList: React.FC<Props> = ({
 
   return (
     <div className="QueryList">
-      <div className={classNames("QueryList-new", { darwin: process.platform === "darwin" })}>
+      <div className="QueryList-new">
         <div className="QueryList-controls">
           <i className="fas fa-plus" onClick={handleClickNew} title="New Query" />
           <i className="fas fa-sync-alt" onClick={handleClickRefresh} title="Reload query list" />

--- a/src/renderer/pages/App/App.css
+++ b/src/renderer/pages/App/App.css
@@ -9,10 +9,6 @@
   width: 68px;
 }
 
-.page-app-menu.darwin {
-  -webkit-app-region: drag;
-}
-
 .page-app-main {
   flex: 1;
   width: 0;

--- a/src/renderer/pages/App/App.tsx
+++ b/src/renderer/pages/App/App.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import classNames from "classnames";
 import Container from "../../flux/Container";
 import GlobalMenu from "../../components/GlobalMenu";
 import { store, AppState } from "./AppStore";
@@ -31,7 +30,7 @@ class App extends React.Component<unknown, AppState> {
 
     return (
       <div className="page-app">
-        <div className={classNames("page-app-menu", { darwin: process.platform === "darwin" })}>
+        <div className="page-app-menu">
           <GlobalMenu selectedPage={this.state.selectedPage} onSelect={Action.selectPage} />
         </div>
         <div className="page-app-main">


### PR DESCRIPTION
## Summary
- Stop using `titleBarStyle: "hidden"` on macOS and show the native title bar instead.
- Fixes the issue where the macOS traffic light buttons (close/minimize/maximize) overflowed the narrow (68px) sidebar onto the query list area.
- Remove the drag regions (`-webkit-app-region: drag` / `no-drag`), `darwin` classNames, and the sidebar `padding-top: 32px` that existed only to accommodate the overlaid window controls.

## Test plan
- [x] Launch the app on macOS and confirm the native title bar is shown.
- [x] Confirm the traffic light buttons no longer overflow the sidebar.
- [x] Confirm there is no extra top padding above the first sidebar icon.
- [x] Confirm the query list / data source list headers still render and work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

before | after
---- | ----
<img width="110" height="55" alt="スクリーンショット 2026-05-28 15 14 13" src="https://github.com/user-attachments/assets/7f9875c7-3876-4aa9-8c61-b3cc5bba1fd5" /> | <img width="140" height="94" alt="スクリーンショット 2026-05-28 15 16 44" src="https://github.com/user-attachments/assets/22927bb8-ca83-49dc-80a9-37770e64efe3" />

